### PR TITLE
Add dropdown for route selection with length display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+urgup_rotalar.html


### PR DESCRIPTION
## Summary
- compute length of sample routes
- add dropdown menu to choose alternative routes
- show route length when selected
- ignore generated files in version control

## Testing
- `python -m py_compile create_urgup_routes.py`
- `python create_urgup_routes.py` *(fails to download OSM data due to network restrictions but succeeds using sample coordinates)*

------
https://chatgpt.com/codex/tasks/task_e_68513f3d60c0832090c6e36dd6e412b6