### PR TITLE
Poi listesinde görünmeme sorununu gider

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -94,14 +94,15 @@ def list_pois():
     
     category = request.args.get('category')
     if category:
-        pois = db.get_pois_by_category(category)
+        # Yeni UI için uyumlu formatta aktif POI'leri getir
+        pois = db.list_pois(category)
         db.disconnect()
         return jsonify(pois)
     # Tüm kategorilerdeki POI'leri döndür
     categories = ['gastronomik', 'kulturel', 'sanatsal', 'doga_macera', 'konaklama']
     all_pois = {}
     for cat in categories:
-        all_pois[cat] = db.get_pois_by_category(cat)
+        all_pois[cat] = db.list_pois(cat)
     db.disconnect()
     return jsonify(all_pois)
 


### PR DESCRIPTION
<!-- Fix POI list not displaying newly added POIs by aligning API response format with UI expectations. -->

<!-- The previous API response for listing POIs did not match the format expected by the UI, specifically lacking the `_id` field and the correct structure for latitude/longitude in detail views. This PR introduces a new `list_pois` method in the database adapter and updates the `/api/pois` endpoint to use it, ensuring data is returned in the `[ {_id, name, category, latitude, longitude, ...} ]` format. -->