### PR TITLE
Poi güncelleme kimliği hatasını düzelt

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -117,6 +117,12 @@ def get_poi(poi_id):
                         return jsonify(poi)
         return jsonify({'error': 'POI not found'}), 404
     
+    # POI ID'nin geçerli olup olmadığını kontrol et
+    try:
+        poi_id = int(poi_id)
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid POI ID format'}), 400
+    
     db = get_db()
     if not db:
         return jsonify({'error': 'Database connection failed'}), 500
@@ -217,6 +223,15 @@ def update_poi(poi_id):
         except Exception as e:
             return jsonify({'error': f'Error updating POI: {str(e)}'}), 500
     
+    # POI ID'nin geçerli olup olmadığını kontrol et
+    if poi_id == 'undefined' or poi_id is None:
+        return jsonify({'error': 'Invalid POI ID'}), 400
+    
+    try:
+        poi_id = int(poi_id)
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid POI ID format'}), 400
+    
     db = get_db()
     if not db:
         return jsonify({'error': 'Database connection failed'}), 500
@@ -251,6 +266,12 @@ def delete_poi(poi_id):
             
         except Exception as e:
             return jsonify({'error': f'Error deleting POI: {str(e)}'}), 500
+    
+    # POI ID'nin geçerli olup olmadığını kontrol et
+    try:
+        poi_id = int(poi_id)
+    except (ValueError, TypeError):
+        return jsonify({'error': 'Invalid POI ID format'}), 400
     
     db = get_db()
     if not db:

--- a/poi_database_adapter.py
+++ b/poi_database_adapter.py
@@ -152,6 +152,8 @@ class PostgreSQLPOIDatabase(POIDatabase):
             result['longitude'] = result.pop('lon')
             # Geriye uyumluluk için coordinates tuple'ı da ekle
             result['coordinates'] = (result['latitude'], result['longitude'])
+            # UI JSON formatında `_id` alanı bekleniyor
+            result['_id'] = result['id']
         
         return dict(result) if result else None
     

--- a/poi_update_bug_fix.md
+++ b/poi_update_bug_fix.md
@@ -1,0 +1,65 @@
+# POI Güncelleme Hatası Düzeltildi
+
+## Problem
+POI (Point of Interest) kayıtlarını güncellerken aşağıdaki hata alınıyordu:
+
+```
+psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type integer: "undefined"
+LINE 1: ...411)'), updated_at = CURRENT_TIMESTAMP WHERE id = 'undefined...
+```
+
+## Kök Sebep
+Hata iki ana nedenden kaynaklanıyordu:
+
+1. **ID Alanı Eşleştirme Sorunu**: `poi_database_adapter.py` dosyasındaki `get_poi_details()` fonksiyonu, veritabanından gelen `id` alanını UI'ın beklediği `_id` alanına dönüştürmüyordu.
+
+2. **JavaScript'te Undefined Değer**: UI'da POI detayı yüklendiğinde `poi._id` undefined olduğu için, güncelleme sırasında "undefined" string'i veritabanına gönderiliyordu.
+
+## Yapılan Düzeltmeler
+
+### 1. Database Adapter Düzeltmesi
+`poi_database_adapter.py` dosyasındaki `get_poi_details()` fonksiyonuna ID alanı eşleştirmesi eklendi:
+
+```python
+if result:
+    # UI detay ekranı latitude ve longitude alanlarını bekliyor
+    result['latitude'] = result.pop('lat')
+    result['longitude'] = result.pop('lon')
+    # Geriye uyumluluk için coordinates tuple'ı da ekle
+    result['coordinates'] = (result['latitude'], result['longitude'])
+    # UI JSON formatında `_id` alanı bekleniyor
+    result['_id'] = result['id']  # ← YENİ SATIR
+```
+
+### 2. API Validasyon Düzeltmeleri
+`poi_api.py` dosyasındaki şu fonksiyonlara ID validasyonu eklendi:
+
+- `get_poi(poi_id)`
+- `update_poi(poi_id)`
+- `delete_poi(poi_id)`
+
+Eklenen validasyon kodu:
+```python
+# POI ID'nin geçerli olup olmadığını kontrol et
+if poi_id == 'undefined' or poi_id is None:  # update_poi için
+    return jsonify({'error': 'Invalid POI ID'}), 400
+
+try:
+    poi_id = int(poi_id)
+except (ValueError, TypeError):
+    return jsonify({'error': 'Invalid POI ID format'}), 400
+```
+
+## Sonuç
+Bu düzeltmelerle:
+- POI detay sayfası doğru `_id` alanıyla yüklenir
+- Geçersiz ID'ler veritabanına gönderilmez
+- Kullanıcı dostu hata mesajları döndürülür
+- POI güncelleme işlemi başarıyla çalışır
+
+## Test
+Düzeltmeleri test etmek için:
+1. Bir POI'yi düzenleme modunda açın
+2. Herhangi bir alanı değiştirin
+3. Kaydet butonuna tıklayın
+4. Güncelleme işleminin başarıyla tamamlandığını doğrulayın


### PR DESCRIPTION
Fix `InvalidTextRepresentation` error during POI updates by mapping `id` to `_id` in details retrieval and adding robust ID validation.

The `get_poi_details` function in `poi_database_adapter.py` did not map the database `id` field to the `_id` field expected by the UI, unlike `list_pois`. This caused the UI to send "undefined" as the POI ID during updates, leading to a PostgreSQL `InvalidTextRepresentation` error. The fix ensures correct ID mapping and adds validation to API endpoints to handle invalid ID formats.