### PR TITLE
Resim URL'si alanını kaldır

### DIFF
--- a/poi_manager_ui.html
+++ b/poi_manager_ui.html
@@ -316,10 +316,6 @@
                                         <input type="text" class="form-control" id="poiTags"
                                             placeholder="etiket1, etiket2, etiket3...">
                                     </div>
-                                    <div class="mb-2">
-                                        <label class="form-label">Resim URL'si</label>
-                                        <input type="url" class="form-control" id="poiImageUrl" placeholder="https://...">
-                                    </div>
                                     
                                     <!-- POI Rating Sistemi (Yeni!) -->
                                     <div class="mb-3" id="ratingSystemSection">
@@ -1012,7 +1008,6 @@
                 document.getElementById('poiLon').value = poi.longitude;
                 document.getElementById('poiDesc').value = poi.description || '';
                 document.getElementById('poiTags').value = (poi.tags || []).join(', ');
-                document.getElementById('poiImageUrl').value = poi.imageUrl || '';
 
                 // Rating'leri yükle (DOM hazır olana kadar bekle)
                 setTimeout(() => {
@@ -1225,11 +1220,10 @@
                 const lon = parseFloat(document.getElementById('poiLon').value);
                 const description = document.getElementById('poiDesc').value;
                 const tags = document.getElementById('poiTags').value.split(',').map(t => t.trim()).filter(Boolean);
-                const imageUrl = document.getElementById('poiImageUrl').value;
 
                 const poiData = {
                     name, category, latitude: lat, longitude: lon,
-                    description, tags, imageUrl
+                    description, tags
                 };
 
                 let response;
@@ -1408,11 +1402,10 @@
                 const category = document.getElementById('poiCategory').value;
                 const description = document.getElementById('poiDesc').value.trim();
                 const tags = document.getElementById('poiTags').value.trim();
-                const imageUrl = document.getElementById('poiImageUrl').value.trim();
 
                 const poiData = {
                     name, category, latitude, longitude,
-                    description, tags, imageUrl
+                    description, tags
                 };
 
                 let response;


### PR DESCRIPTION
Remove the 'Resim URL'si' (Image URL) field from the POI manager UI as requested.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5a5ea8ab-6684-4861-bef0-60f2098f24a2) · [Cursor](https://cursor.com/background-agent?bcId=bc-5a5ea8ab-6684-4861-bef0-60f2098f24a2)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)