### PR TITLE
Fix backup script indentation and document install/backup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ brew install python3 geos proj gdal
 
 ### Adım Adım Kurulum
 
+#### Otomatik Kurulum (Tercih Edilen)
+```bash
+./install.sh
+```
+
 #### 1. Projeyi İndirin
 ```bash
 # Depoyu klonlayın
@@ -378,6 +383,20 @@ db.dropDatabase()
 sudo -u postgres psql
 DROP DATABASE poi_db;
 ```
+
+### Yedekleme ve Geri Yükleme
+Projeyi ve veritabanını yedeklemek için `backup_restore.sh` scriptini kullanabilirsiniz.
+```bash
+# Yedek oluştur
+./backup_restore.sh backup
+
+# Yedekleri listele
+./backup_restore.sh list
+
+# Geri yükleme
+./backup_restore.sh restore <yedek_adi>
+```
+Detaylı açıklama için `YEDEKLEME_REHBERI.md` dosyasına bakabilirsiniz.
 
 ## 📚 Detaylı Kullanım
 

--- a/backup_system.py
+++ b/backup_system.py
@@ -232,7 +232,7 @@ class POIBackupSystem:
                 logger.warning(f"Yedekleme bilgisi okunamadı {info_file}: {e}")
         
         return backups 
-   def restore_files(self, backup_name):
+    def restore_files(self, backup_name):
         """Program dosyalarını geri yükle"""
         logger.info(f"Program dosyaları geri yükleniyor: {backup_name}")
         


### PR DESCRIPTION
## Summary
- correct indentation error in `backup_system.py`
- mention `install.sh` script in README
- document `backup_restore.sh` usage in README

## Testing
- `bash -n install.sh`
- `bash -n backup_restore.sh`
- `python -m py_compile *.py`
- `pip install -r requirements.txt`
- `python category_route_planner.py --help`

------
https://chatgpt.com/codex/tasks/task_e_687feaca31e8832092b71cba9cd26461