### PR TITLE
Add poi_ratings table and migration script

### DIFF
--- a/migrate_poi_ratings.py
+++ b/migrate_poi_ratings.py
@@ -1,0 +1,39 @@
+import argparse
+import psycopg2
+from psycopg2.extras import RealDictCursor
+
+
+def migrate(connection_string: str, remove_from_attributes: bool = True):
+    conn = psycopg2.connect(connection_string)
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+
+    cur.execute("SELECT id, attributes->'ratings' AS ratings FROM pois WHERE attributes ? 'ratings'")
+    rows = cur.fetchall()
+    insert_query = """
+        INSERT INTO poi_ratings (poi_id, category, rating)
+        VALUES (%s, %s, %s)
+        ON CONFLICT (poi_id, category) DO UPDATE SET rating = EXCLUDED.rating
+    """
+    for row in rows:
+        ratings = row['ratings'] or {}
+        for category, rating in ratings.items():
+            try:
+                rating_int = int(rating)
+            except (TypeError, ValueError):
+                rating_int = 0
+            cur.execute(insert_query, (row['id'], category, rating_int))
+        if remove_from_attributes:
+            cur.execute("UPDATE pois SET attributes = attributes - 'ratings' WHERE id = %s", (row['id'],))
+
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Move ratings from attributes JSONB to poi_ratings table')
+    parser.add_argument('connection_string', help='PostgreSQL connection string')
+    parser.add_argument('--keep-jsonb', action='store_true', help='Keep ratings data in attributes JSONB')
+    args = parser.parse_args()
+    migrate(args.connection_string, remove_from_attributes=not args.keep_jsonb)
+    print('Migration completed.')

--- a/poi_database_adapter.py
+++ b/poi_database_adapter.py
@@ -155,13 +155,9 @@ class PostgreSQLPOIDatabase(POIDatabase):
             # UI JSON formatında `_id` alanı bekleniyor
             result['_id'] = result['id']
             
-            # Rating sistemini ekle (JSONB attributes'tan al)
-            if result.get('attributes') and isinstance(result['attributes'], dict):
-                ratings = result['attributes'].get('ratings', {})
-                result['ratings'] = ratings
-            else:
-                # Varsayılan rating'ler
-                result['ratings'] = self.get_default_ratings()
+            # Ratingleri yeni tablodan oku
+            ratings = self.get_poi_ratings(poi_id)
+            result['ratings'] = ratings if ratings else self.get_default_ratings()
         
         return dict(result) if result else None
 
@@ -179,6 +175,26 @@ class PostgreSQLPOIDatabase(POIDatabase):
             'yemek': 0,
             'gece_hayati': 0
         }
+
+    def get_poi_ratings(self, poi_id: int) -> Dict[str, int]:
+        """Belirli bir POI'nin tüm puanlarını döndür"""
+        query = "SELECT category, rating FROM poi_ratings WHERE poi_id = %s"
+        with self.conn.cursor() as cur:
+            cur.execute(query, (poi_id,))
+            rows = cur.fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def update_poi_ratings(self, poi_id: int, ratings: Dict[str, int]) -> None:
+        """POI ratinglerini upsert et"""
+        insert_q = (
+            "INSERT INTO poi_ratings (poi_id, category, rating) "
+            "VALUES (%s, %s, %s) "
+            "ON CONFLICT (poi_id, category) DO UPDATE SET rating = EXCLUDED.rating"
+        )
+        with self.conn.cursor() as cur:
+            for category, rating in ratings.items():
+                cur.execute(insert_q, (poi_id, category, rating))
+        self.conn.commit()
     
     def search_nearby_pois(self, lat: float, lon: float, radius_meters: float) -> List[Dict[str, Any]]:
         """Yakındaki POI'leri ara"""
@@ -260,6 +276,7 @@ class PostgreSQLPOIDatabase(POIDatabase):
         set_clauses = []
         values = []
         attributes_to_update = {}
+        ratings_updated = False
         
         for key, value in update_data.items():
             if key in ["latitude", "longitude"]:
@@ -282,13 +299,13 @@ class PostgreSQLPOIDatabase(POIDatabase):
             values.append(update_data["longitude"])
             values.append(update_data["latitude"])
         
-        # Handle ratings updates - özel işlem
+        # Handle ratings updates - yeni tablo
         if "ratings" in update_data:
             ratings_data = update_data["ratings"]
             if isinstance(ratings_data, dict):
-                # Ratings'i validate et
                 validated_ratings = self.validate_ratings(ratings_data)
-                attributes_to_update["ratings"] = validated_ratings
+                self.update_poi_ratings(poi_id, validated_ratings)
+                ratings_updated = True
                 print(f"✅ POI {poi_id} için rating'ler güncellendi: {validated_ratings}")
         
         # Handle attributes updates
@@ -304,8 +321,8 @@ class PostgreSQLPOIDatabase(POIDatabase):
             set_clauses.append("attributes = %s")
             values.append(Json(current_attributes))
         
-        if not set_clauses:
-            return False
+        if not set_clauses and not attributes_to_update:
+            return ratings_updated
             
         set_clause = ", ".join(set_clauses)
         query = f"UPDATE pois SET {set_clause}, updated_at = CURRENT_TIMESTAMP WHERE id = %s"
@@ -343,14 +360,18 @@ class PostgreSQLPOIDatabase(POIDatabase):
             raise RuntimeError("Veritabanı bağlantısı yok")
 
         base_query = """
-            SELECT 
-                id, 
-                name, 
-                category, 
-                ST_Y(location::geometry) as latitude, 
-                ST_X(location::geometry) as longitude, 
+            SELECT
+                id,
+                name,
+                category,
+                ST_Y(location::geometry) as latitude,
+                ST_X(location::geometry) as longitude,
                 description,
-                attributes
+                (
+                    SELECT json_object_agg(category, rating)
+                    FROM poi_ratings pr
+                    WHERE pr.poi_id = pois.id
+                ) AS ratings
             FROM pois
             WHERE is_active = true
         """
@@ -378,9 +399,8 @@ class PostgreSQLPOIDatabase(POIDatabase):
             }
             
             # Rating sistemini ekle
-            if row.get('attributes') and isinstance(row['attributes'], dict):
-                ratings = row['attributes'].get('ratings', {})
-                poi_data['ratings'] = ratings if ratings else self.get_default_ratings()
+            if row.get('ratings') and isinstance(row['ratings'], dict):
+                poi_data['ratings'] = row['ratings']
             else:
                 poi_data['ratings'] = self.get_default_ratings()
             

--- a/poi_database_design.md
+++ b/poi_database_design.md
@@ -56,6 +56,16 @@ CREATE TABLE poi_3d_models (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- POI puanları tablosu (her kategori için ayrı satır)
+CREATE TABLE poi_ratings (
+    poi_id INTEGER REFERENCES pois(id) ON DELETE CASCADE,
+    category TEXT,
+    rating INTEGER CHECK (rating BETWEEN 0 AND 100),
+    PRIMARY KEY (poi_id, category)
+);
+-- Her bir kategori için puanlar bu tabloda tutulur. Attributes JSONB alanındaki
+-- eski rating verileri buraya taşınabilir.
+
 -- Kategoriler tablosu (genişletilebilir)
 CREATE TABLE categories (
     id SERIAL PRIMARY KEY,
@@ -71,6 +81,8 @@ CREATE INDEX idx_poi_location ON pois USING GIST(location);
 CREATE INDEX idx_poi_category ON pois(category);
 CREATE INDEX idx_poi_active ON pois(is_active);
 CREATE INDEX idx_poi_attributes ON pois USING GIN(attributes);
+CREATE INDEX idx_poi_ratings_poi_id ON poi_ratings(poi_id);
+CREATE INDEX idx_poi_ratings_category ON poi_ratings(category);
 ```
 
 ### Örnek Veri Ekleme

--- a/setup_poi_database.py
+++ b/setup_poi_database.py
@@ -176,12 +176,23 @@ def setup_postgresql_database(connection_string):
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
         """)
+
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS poi_ratings (
+                poi_id INTEGER REFERENCES pois(id) ON DELETE CASCADE,
+                category TEXT,
+                rating INTEGER CHECK (rating BETWEEN 0 AND 100),
+                PRIMARY KEY (poi_id, category)
+            );
+        """)
         
         # İndeksleri oluştur
         cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_location ON pois USING GIST(location);")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_category ON pois(category);")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_active ON pois(is_active);")
         cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_attributes ON pois USING GIN(attributes);")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_ratings_poi_id ON poi_ratings(poi_id);")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_poi_ratings_category ON poi_ratings(category);")
         
         print("✅ Tablolar ve indeksler oluşturuldu")
         


### PR DESCRIPTION
## Summary
- add new `poi_ratings` table to the DB design
- create the table and indices in `setup_poi_database.py`
- store/read ratings from the new table in `poi_database_adapter`
- update rating search in `poi_api.py`
- add helper script `migrate_poi_ratings.py` for migrating JSONB ratings

## Testing
- `python3 -m py_compile poi_database_adapter.py poi_api.py setup_poi_database.py migrate_poi_ratings.py`


------
https://chatgpt.com/codex/tasks/task_e_688012325ac88320bf3751c2c98e9945