### PR TITLE
Veritabanı yapısını ve poiler ratinglerini incele

### DIFF
--- a/poi_database_adapter.py
+++ b/poi_database_adapter.py
@@ -353,24 +353,24 @@ class PostgreSQLPOIDatabase(POIDatabase):
             return cur.rowcount > 0
 
     def validate_ratings(self, ratings: Dict[str, Any]) -> Dict[str, int]:
-        """Rating verilerini validate et ve temizle"""
+        """Rating verilerini validate et ve temizle. Tüm gönderilen kategorileri sakla, valid olmayanlar için uyarı ver."""
         valid_categories = {
             'tarihi', 'sanat_kultur', 'doga', 'eglence', 'alisveris', 
             'spor', 'macera', 'rahatlatici', 'yemek', 'gece_hayati'
         }
-        
         validated = {}
-        for category in valid_categories:
-            if category in ratings:
-                try:
-                    # 0-100 arası olup olmadığını kontrol et
-                    value = int(ratings[category])
-                    validated[category] = max(0, min(100, value))  # 0-100 arası sınırla
-                except (ValueError, TypeError):
-                    validated[category] = 0
-            else:
+        for category, value in ratings.items():
+            try:
+                value_int = int(value)
+                validated[category] = max(0, min(100, value_int))
+                if category not in valid_categories:
+                    print(f"[WARN] Bilinmeyen rating kategorisi: {category}")
+            except (ValueError, TypeError):
                 validated[category] = 0
-        
+        # Eksik valid kategoriler için sıfır ekle
+        for category in valid_categories:
+            if category not in validated:
+                validated[category] = 0
         return validated
 
     def list_pois(self, category: Optional[str] = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Modify `validate_ratings` to persist all incoming rating categories, resolving an issue where ratings were not saved due to category mismatches.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation of `validate_ratings` would discard rating categories not explicitly defined in `valid_categories`. This led to a bug where frontend-sent ratings with slightly different or new category names would not be saved, appearing to reset or disappear upon page refresh. The updated logic ensures all submitted ratings are processed and stored, while still providing a warning for unknown categories.

---

[Open in Web](https://www.cursor.com/agents?id=bc-40fe3185-2d92-40a3-a3e3-84cabb5f5930) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-40fe3185-2d92-40a3-a3e3-84cabb5f5930)