### PR TITLE
Poll rating save and retrieval fix

### DIFF
--- a/poi_database_adapter.py
+++ b/poi_database_adapter.py
@@ -308,7 +308,7 @@ class PostgreSQLPOIDatabase(POIDatabase):
                 # Valid database column - update directly
                 set_clauses.append(f"{db_column} = %s")
                 values.append(value)
-            else:
+            elif key != "ratings":  # ratings'i attributes'a ekleme!
                 # Store in attributes JSONB column
                 attributes_to_update[key] = value
         


### PR DESCRIPTION
Remove redundant storage of POI ratings in the `attributes` JSONB column.

Previously, POI ratings were updated in the dedicated `poi_ratings` table but also redundantly written to the `attributes` JSONB column. This redundancy caused updated ratings to appear reset or not persist, as the system might have been reading from the outdated `attributes` column.

---

[Open in Web](https://www.cursor.com/agents?id=bc-08fbd0f9-7711-439e-938a-1a9797abe48a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-08fbd0f9-7711-439e-938a-1a9797abe48a)