### PR TITLE
Fix map marker popup issue

### DIFF
--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -3130,38 +3130,26 @@
 
 /* Pulse animation for active markers */
 @keyframes markerPulse {
-    0% { 
+    0% {
         box-shadow: 0 0 0 0 rgba(102, 126, 234, 0.4);
-        transform: scale(1.08);
     }
     50% {
-        transform: scale(1.12);
-    }
-    70% { 
         box-shadow: 0 0 0 8px rgba(102, 126, 234, 0);
-        transform: scale(1.08);
     }
-    100% { 
+    100% {
         box-shadow: 0 0 0 0 rgba(102, 126, 234, 0);
-        transform: scale(1.08);
     }
 }
 
 @keyframes lowScoreMarkerPulse {
-    0% { 
+    0% {
         box-shadow: 0 0 0 0 rgba(156, 163, 175, 0.3);
-        transform: scale(1.05);
     }
     50% {
-        transform: scale(1.08);
-    }
-    70% { 
         box-shadow: 0 0 0 6px rgba(156, 163, 175, 0);
-        transform: scale(1.05);
     }
-    100% { 
+    100% {
         box-shadow: 0 0 0 0 rgba(156, 163, 175, 0);
-        transform: scale(1.05);
     }
 }
 

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -2039,7 +2039,8 @@ function createSimpleRoute(waypoints) {
                         <small>(Gerçek yol rotası değil)</small>
                     </p>
                 </div>
-                `
+                `,
+        { autoPan: false }
     );
 
     // Add route details panel click event
@@ -2818,7 +2819,8 @@ async function setStartLocation() {
                                     Doğruluk: ±${Math.round(location.accuracy)}m
                                 </div>
                             </div>
-                            `
+                            `,
+                    { autoPan: false }
                 );
 
             // Center map on user location
@@ -4014,7 +4016,8 @@ async function initializeMap(recommendationData) {
                             </div>
                         `, {
                 maxWidth: 400,
-                className: 'custom-popup'
+                className: 'custom-popup',
+                autoPan: false
             });
 
         // Marker'ı listeye ekle ve düşük puanlı ise başlangıçta gizle


### PR DESCRIPTION
## Summary
- disable Leaflet's autoPan feature for popups
- prevent CSS animations from overriding marker position

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688be6c8ca0083209c0b2b6411d79ca5