### PR TITLE
Handle missing route geometry gracefully

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4470,16 +4470,20 @@ async function loadAndDisplayRouteGeometry(routeId) {
         if (response.ok) {
             const geometryData = await response.json();
             console.log('✅ Route geometry loaded:', geometryData);
-            
+
             if (geometryData.success && geometryData.geometry) {
                 displaySavedRouteGeometry(geometryData.geometry);
                 return true;
+            } else {
+                showNotification('⚠️ Rota geometrisi bulunamadı. Ön izleme için yalnızca düz çizgiler gösteriliyor.', 'warning');
             }
         } else {
             console.log('ℹ️ No saved geometry found for route:', routeId);
+            showNotification('⚠️ Rota geometrisi bulunamadı. Ön izleme için yalnızca düz çizgiler gösteriliyor.', 'warning');
         }
     } catch (error) {
         console.error('❌ Error loading route geometry:', error);
+        showNotification('⚠️ Rota geometrisi bulunamadı. Ön izleme için yalnızca düz çizgiler gösteriliyor.', 'warning');
     }
     
     return false;


### PR DESCRIPTION
## Summary
- Notify users when route geometry can't be loaded
- Clarify that preview falls back to straight lines

## Testing
- `python run_all_tests.py` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6892689aef1883209d1e56a066f003d1