### PR TITLE
Handle non-JSON responses when importing route files

### DIFF
--- a/poi_manager_ui.html
+++ b/poi_manager_ui.html
@@ -5564,12 +5564,15 @@
                     }
                 });
 
+                // Response body can only be read once; create a clone for error handling
+                const responseClone = response.clone();
+
                 let result;
                 try {
                     result = await response.json();
                 } catch (jsonError) {
                     // JSON parse hatası - muhtemelen HTML error sayfası döndü
-                    const textResponse = await response.text();
+                    const textResponse = await responseClone.text();
                     console.error('API Response (not JSON):', textResponse);
                     throw new Error(`API hatası (${response.status}): JSON parse edilemedi`);
                 }


### PR DESCRIPTION
## Summary
- Prevent reading the response body twice during route import
- Log API responses that aren't JSON and surface a clear error

## Testing
- `python run_all_tests.py` *(fails: Failed Test Suites: Backend Unit Tests - Route Service, API Core Functionality Tests)*

------
https://chatgpt.com/codex/tasks/task_e_68939d7081f08320ae4de90fd1b78035