### PR TITLE
Fix login redirect loop for POI manager

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -210,7 +210,7 @@ def login_page():
             <p>Devam etmek için giriş yapın</p>
         </div>
         
-        <form id="loginForm">
+        <form id="loginForm" method="POST" action="/auth/login">
             <div class="form-group">
                 <label for="password">Şifre</label>
                 <input type="password" id="password" name="password" required placeholder="Şifrenizi girin">
@@ -232,6 +232,9 @@ def login_page():
         const btnText = document.getElementById('btnText');
         const btnLoading = document.getElementById('btnLoading');
         const messageDiv = document.getElementById('message');
+
+        const params = new URLSearchParams(window.location.search);
+        const nextUrl = params.get('next');
         
         function showMessage(text, type = 'info') {
             messageDiv.innerHTML = `<div class="message ${type}">${text}</div>`;
@@ -273,15 +276,23 @@ def login_page():
                         remember_me: false,
                         csrf_token: null
                     }),
-                    credentials: 'same-origin'
+                    credentials: 'include'
                 });
                 
                 const data = await response.json();
                 
                 if (response.ok && data.success) {
                     showMessage('✅ Giriş başarılı! Yönlendiriliyorsunuz...', 'success');
+
+                    let redirectUrl = '/';
+                    try {
+                        if (nextUrl && nextUrl.startsWith('/') && !nextUrl.includes('://') && !nextUrl.includes('\\')) {
+                            redirectUrl = nextUrl;
+                        }
+                    } catch (err) {}
+
                     setTimeout(() => {
-                        window.location.href = '/';
+                        window.location.href = redirectUrl;
                     }, 1500);
                 } else {
                     let errorMessage = data.error || data.message || 'Giriş başarısız';

--- a/poi_manager_enhanced.html
+++ b/poi_manager_enhanced.html
@@ -3631,7 +3631,9 @@
                 console.log('🔐 Checking auth status...');
 
                 try {
-                    const response = await fetch('/auth/status');
+                    const response = await fetch('/auth/status', {
+                        credentials: 'include'
+                    });
                     console.log('🔐 Auth status response:', response.status, response.ok);
 
                     if (response.ok) {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -156,7 +156,7 @@ class AuthManager {
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(loginData),
-                credentials: 'same-origin'
+                credentials: 'include'
             });
             
             const data = await response.json();
@@ -189,9 +189,18 @@ class AuthManager {
         // Start session monitoring for authenticated users
         this.startSessionMonitoring();
         
+        // Determine redirect target
+        const params = new URLSearchParams(window.location.search);
+        const nextParam = params.get('next');
+        let redirectUrl = data.redirect_url || '/';
+
+        if (nextParam && nextParam.startsWith('/') && !nextParam.includes('://') && !nextParam.includes('\\')) {
+            redirectUrl = nextParam;
+        }
+
         // Redirect after short delay
         setTimeout(() => {
-            window.location.href = data.redirect_url || '/';
+            window.location.href = redirectUrl;
         }, 1500);
     }
     


### PR DESCRIPTION
## Summary
- Submit login form via POST to keep credentials out of the URL
- Include cookies on login requests so sessions persist across the POI manager

## Testing
- `python run_all_tests.py` *(fails: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_6895e8ff3b1c8320a30e702fe0767a1a