### PR TITLE
Use next URL parameter after login

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -236,6 +236,10 @@ def login_page():
         const btnText = document.getElementById('btnText');
         const btnLoading = document.getElementById('btnLoading');
         const messageDiv = document.getElementById('message');
+
+        // Read optional next parameter from URL
+        const urlParams = new URLSearchParams(window.location.search);
+        const nextUrl = urlParams.get('next');
         
         function showMessage(text, type = 'info') {
             messageDiv.innerHTML = `<div class="message ${type}">${text}</div>`;
@@ -285,7 +289,7 @@ def login_page():
                 if (response.ok && data.success) {
                     showMessage('✅ Giriş başarılı! Yönlendiriliyorsunuz...', 'success');
                     setTimeout(() => {
-                        window.location.href = '/';
+                        window.location.href = nextUrl ? nextUrl : '/';
                     }, 1500);
                 } else {
                     let errorMessage = data.error || data.message || 'Giriş başarısız';


### PR DESCRIPTION
## Summary
- Read `next` query parameter in the login page script and redirect there on successful login

## Testing
- `POI_SESSION_SECRET_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa POI_ADMIN_PASSWORD_HASH='$2b$12$rPQGowYT2jsP0BUboVFTfOA5Kd.Z00wAmBe9yK5an1oAIwdioaGPi' python -m pytest` *(fails: 31 failed, 189 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899a048be14832096300c0c4004780c