### PR TITLE
Fix predefined route display when selecting route

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -3596,19 +3596,20 @@ function displayRouteOnMap(route) {
         console.log('🔍 No valid geometry found, trying POI markers...');
         if (route.pois && route.pois.length > 0) {
             console.log('🔍 Route has', route.pois.length, 'POIs');
-            const validPois = route.pois.filter(poi => poi.lat && poi.lng);
+            const validPois = route.pois.filter(poi => poi.lat && (poi.lng || poi.lon));
             console.log('🔍 Valid POIs with coordinates:', validPois.length);
-            
+
             if (validPois.length > 0) {
                 const bounds = L.latLngBounds();
-                
+
                 validPois.forEach((poi, index) => {
-                    const marker = L.marker([poi.lat, poi.lng], {
+                    const lng = poi.lng !== undefined ? poi.lng : poi.lon;
+                    const marker = L.marker([poi.lat, lng], {
                         icon: L.divIcon({
                             className: 'route-poi-marker',
                             html: `<div style="
-                                background: ${routeColor}; 
-                                color: white; 
+                                background: ${routeColor};
+                                color: white;
                                 width: 30px; 
                                 height: 30px; 
                                 border-radius: 50%; 
@@ -3623,16 +3624,16 @@ function displayRouteOnMap(route) {
                             iconAnchor: [15, 15]
                         })
                     }).addTo(predefinedMap);
-                    
+
                     marker.bindPopup(`
                         <div style="text-align: center;">
                             <h5 style="margin: 0 0 8px 0;">${poi.name}</h5>
                             <p style="margin: 0; font-size: 12px; color: #666;">Durak ${index + 1}</p>
                         </div>
                     `);
-                    
+
                     predefinedMapLayers.push(marker);
-                    bounds.extend([poi.lat, poi.lng]);
+                    bounds.extend([poi.lat, lng]);
                 });
                 
                 // Fit map to POI bounds
@@ -3902,7 +3903,7 @@ function showNoRoutesMessage(message = 'Seçilen kriterlere uygun rota bulunamad
     }
 }
 
-function showRouteDetails(route) {
+async function showRouteDetails(route) {
     console.log('📋 Showing route details for:', route);
     
     const modal = document.getElementById('routeDetailModal');
@@ -3928,14 +3929,16 @@ function showRouteDetails(route) {
     
     // Show modal
     modal.classList.add('show');
-    
-    // Display route on predefined map
+
+    // Load route details and update map when done
+    const detailed = await loadRouteDetails(route, modalBody);
+    const detailedRoute = detailed && (detailed.success ? detailed.route : detailed);
+    if (detailedRoute) {
+        Object.assign(route, detailedRoute);
+    }
     displayRouteOnMap(route);
-    
-    // Load route details
-    loadRouteDetails(route, modalBody);
-    
-    // Setup select button
+
+    // Setup select button with updated route data
     selectBtn.onclick = () => selectPredefinedRoute(route);
     
     // Setup close functionality
@@ -3976,10 +3979,11 @@ async function loadRouteDetails(route, container) {
     try {
         // Fetch detailed route information including POIs
         const response = await fetch(`${apiBase}/routes/${route.id}`);
-        
+
         if (response.ok) {
             const detailedRoute = await response.json();
             displayRouteDetails(detailedRoute, container);
+            return detailedRoute;
         } else {
             throw new Error(`HTTP ${response.status}`);
         }
@@ -3992,6 +3996,7 @@ async function loadRouteDetails(route, container) {
                 <p style="font-size: 0.9rem; margin-top: 8px;">Lütfen daha sonra tekrar deneyin.</p>
             </div>
         `;
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary
- Load detailed route data before displaying and selecting predefined routes
- Accept POIs using either `lon` or `lng` properties when drawing route markers

## Testing
- `pytest` *(fails: Configuration validation failed - Required configuration POI_SESSION_SECRET_KEY is missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899ad06d3948320afca766a8e9adc37