### PR TITLE
Add route calculation button to route editor

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -2752,16 +2752,28 @@ def admin_associate_route_pois(route_id):
             return jsonify({'error': 'Invalid CSRF token'}), 403
         
         poi_associations = data.get('pois', [])
-        
+
         if not isinstance(poi_associations, list):
             return jsonify({'error': 'POIs must be a list'}), 400
-        
+
+        geometry_segments = data.get('geometry')
+        total_distance = data.get('total_distance', 0)
+        estimated_time = data.get('estimated_time', 0)
+        waypoints = data.get('waypoints', [])
+
         if not route_service.connect():
             return jsonify({'error': 'Database connection failed'}), 500
-        
-        success = route_service.associate_pois(route_id, poi_associations)
+
+        success = route_service.associate_pois(
+            route_id,
+            poi_associations,
+            geometry_segments=geometry_segments,
+            total_distance=total_distance,
+            estimated_time=estimated_time,
+            waypoints=waypoints,
+        )
         route_service.disconnect()
-        
+
         if success:
             return jsonify({'message': 'POI associations updated successfully'})
         else:

--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -1393,6 +1393,7 @@
         let searchTimeout = null;
         let associatedPoiIdSet = new Set();
         let associatedPoiOrderedIds = [];
+        let allPoisForAssociation = [];
         let csrfToken = null;
         
         // Rate limiting için
@@ -3488,6 +3489,11 @@
                                         </div>
                                     </div>
                                 </div>
+                                <div class="mt-3">
+                                    <button type="button" class="btn btn-primary" onclick="buildAndSaveRouteFromAssociatedPOIs()">
+                                        <i class="fas fa-route me-1"></i>Rota Hesapla
+                                    </button>
+                                </div>
                             </div>
                         </div>
 
@@ -3780,6 +3786,7 @@
                         });
                     }
                     console.log('Processed all POIs:', allPOIs.length);
+                    allPoisForAssociation = allPOIs.slice();
                 } else {
                     console.error('Failed to load POIs:', poisResponse.status);
                     throw new Error('POI\'ler yüklenemedi');
@@ -4271,7 +4278,7 @@
                 showNotification('Rota geometri kaydedildi', 'success');
                 await loadRoutes();
                 // Önizleme için vurgula
-                highlightRouteOnMap(allRoutes.find(r => getRouteId(r) === getRouteId(currentRoute)) || currentRoute);
+                await showSelectedRouteOnMap(allRoutes.find(r => getRouteId(r) === getRouteId(currentRoute)) || currentRoute);
             } catch (e) {
                 console.error('Build route error:', e);
                 showNotification('Rota oluşturma/kaydetme hatası', 'error');

--- a/test_route_service.py
+++ b/test_route_service.py
@@ -249,8 +249,42 @@ class TestRouteService(unittest.TestCase):
     def test_associate_pois_empty_list(self):
         """Associate POIs with empty list test"""
         result = self.service.associate_pois(1, [])
-        
+
         self.assertTrue(result)
+
+    @patch.object(RouteService, 'save_route_geometry', return_value=True)
+    def test_associate_pois_with_geometry_calls_save(self, mock_save):
+        """associate_pois should save geometry when provided"""
+        poi_associations = [
+            {
+                'poi_id': 1,
+                'order_in_route': 1,
+                'is_mandatory': True,
+                'estimated_time_at_poi': 20
+            }
+        ]
+
+        geometry = [
+            {
+                'coordinates': [
+                    {'lat': 38.0, 'lng': 34.0},
+                    {'lat': 38.1, 'lng': 34.1}
+                ]
+            }
+        ]
+
+        with patch.object(self.service, '_execute_query', side_effect=[1, 1]):
+            result = self.service.associate_pois(
+                1,
+                poi_associations,
+                geometry_segments=geometry,
+                total_distance=1000,
+                estimated_time=600,
+                waypoints=[{'lat': 38.0, 'lng': 34.0}, {'lat': 38.1, 'lng': 34.1}]
+            )
+
+        self.assertTrue(result)
+        mock_save.assert_called_once()
     
     def test_search_routes(self):
         """Search routes test"""
@@ -480,12 +514,53 @@ class TestRouteService(unittest.TestCase):
         
         with patch.object(self.service, '_execute_query', return_value=[]) as mock_query:
             self.service.search_routes(dangerous_input)
-            
+
             # Verify the query was called with parameterized input
             mock_query.assert_called_once()
             args, kwargs = mock_query.call_args
             # The dangerous input should be passed as a parameter, not concatenated
             self.assertIn('%', args[0])  # Should contain parameter placeholders
+
+    @patch('route_service.ElevationService')
+    def test_save_route_geometry_generates_elevation(self, mock_elev):
+        """save_route_geometry should generate elevation profile"""
+        mock_instance = mock_elev.return_value
+        mock_profile = {
+            'points': [],
+            'stats': {
+                'min_elevation': 100,
+                'max_elevation': 150,
+                'elevation_gain': 50,
+                'total_ascent': 50,
+                'total_descent': 0
+            },
+            'total_distance': 1000,
+            'point_count': 2,
+            'resolution': 10
+        }
+        mock_instance.generate_elevation_profile_from_geometry.return_value = mock_profile
+
+        geometry_segments = [
+            {'coordinates': [
+                {'lat': 38.0, 'lng': 34.0},
+                {'lat': 38.1, 'lng': 34.1}
+            ]}
+        ]
+
+        with patch.object(self.service, '_execute_query', side_effect=[1, {'has_geometry': True}]) as mock_exec:
+            result = self.service.save_route_geometry(
+                1,
+                geometry_segments,
+                total_distance=1000,
+                estimated_time=600,
+                waypoints=[{'lat': 38.0, 'lng': 34.0}, {'lat': 38.1, 'lng': 34.1}]
+            )
+
+            self.assertTrue(result)
+            mock_elev.assert_called_once()
+            mock_instance.generate_elevation_profile_from_geometry.assert_called_once()
+            first_call = mock_exec.call_args_list[0]
+            self.assertIn('elevation_profile', first_call[0][0])
 
 
 class TestRouteServiceIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add **Rota Hesapla** button to route management page to build and persist routes from associated POIs
- posting geometry saves distance, time and elevation profile for static routes
- fix undefined POI list reference when constructing routes from associated points
- use existing `showSelectedRouteOnMap` helper instead of removed `highlightRouteOnMap`

## Testing
- `pytest test_route_service.py::TestRouteService::test_save_route_geometry_generates_elevation -q`
- `pytest test_route_service.py::TestRouteService::test_associate_pois_with_geometry_calls_save -q`
- `POI_SESSION_SECRET_KEY=abcdefghijklmnopqrstuvwxyz1234567890abcd POI_ADMIN_PASSWORD_HASH='$2b$12$K/uoTR1GnndvrYJL/1Ddb.NsYManIeZDV4mQJzNw2K6JqqPiRWa1u' pytest test_api_endpoints.py::TestAdminRouteAPIEndpoints::test_admin_associate_pois_with_geometry -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0f08a0e88320aa65e5ff8ba52f54