### PR TITLE
Add route calculation button to route editor

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -2752,16 +2752,28 @@ def admin_associate_route_pois(route_id):
             return jsonify({'error': 'Invalid CSRF token'}), 403
         
         poi_associations = data.get('pois', [])
-        
+
         if not isinstance(poi_associations, list):
             return jsonify({'error': 'POIs must be a list'}), 400
-        
+
+        geometry_segments = data.get('geometry')
+        total_distance = data.get('total_distance', 0)
+        estimated_time = data.get('estimated_time', 0)
+        waypoints = data.get('waypoints', [])
+
         if not route_service.connect():
             return jsonify({'error': 'Database connection failed'}), 500
-        
-        success = route_service.associate_pois(route_id, poi_associations)
+
+        success = route_service.associate_pois(
+            route_id,
+            poi_associations,
+            geometry_segments=geometry_segments,
+            total_distance=total_distance,
+            estimated_time=estimated_time,
+            waypoints=waypoints,
+        )
         route_service.disconnect()
-        
+
         if success:
             return jsonify({'message': 'POI associations updated successfully'})
         else:

--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -973,7 +973,7 @@
                 </a>
             </nav>
             <div class="header-actions">
-                <button class="btn btn-primary" onclick="showCreateRouteModal()">
+                <button class="btn btn-primary" onclick="createAndEditRoute()">
                     <i class="fas fa-plus me-1"></i>
                     Yeni Rota
                 </button>
@@ -1393,6 +1393,7 @@
         let searchTimeout = null;
         let associatedPoiIdSet = new Set();
         let associatedPoiOrderedIds = [];
+        let allPoisForAssociation = [];
         let csrfToken = null;
         
         // Rate limiting için
@@ -3102,147 +3103,15 @@
             showNotification('Harita temizlendi', 'success');
         }
 
-        function showCreateRouteModal() {
-            // Create modal HTML
-            const modalHtml = `
-                <div class="modal fade" id="createRouteModal" tabindex="-1" aria-labelledby="createRouteModalLabel" aria-hidden="true">
-                    <div class="modal-dialog modal-lg">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="createRouteModalLabel">
-                                    <i class="fas fa-plus-circle me-2"></i>Yeni Rota Oluştur
-                                </h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                            </div>
-                            <div class="modal-body">
-                                <form id="createRouteForm">
-                                    <div class="mb-3">
-                                        <label for="routeName" class="form-label">Rota Adı *</label>
-                                        <input type="text" class="form-control" id="routeName" required>
-                                    </div>
-                                    
-                                    <div class="mb-3">
-                                        <label for="routeDescription" class="form-label">Açıklama</label>
-                                        <textarea class="form-control" id="routeDescription" rows="3"></textarea>
-                                    </div>
-                                    
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="mb-3">
-                                                <label for="routeType" class="form-label">Rota Tipi *</label>
-                                                <select class="form-select" id="routeType" required>
-                                                    <option value="">Seçiniz</option>
-                                                    <option value="walking">Yürüyüş</option>
-                                                    <option value="hiking">Doğa Yürüyüşü</option>
-                                                    <option value="cycling">Bisiklet</option>
-                                                    <option value="driving">Araç</option>
-                                                </select>
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <div class="mb-3">
-                                                <label for="difficultyLevel" class="form-label">Zorluk Seviyesi *</label>
-                                                <select class="form-select" id="difficultyLevel" required>
-                                                    <option value="">Seçiniz</option>
-                                                    <option value="1">1 - Çok Kolay</option>
-                                                    <option value="2">2 - Kolay</option>
-                                                    <option value="3">3 - Orta</option>
-                                                    <option value="4">4 - Zor</option>
-                                                    <option value="5">5 - Çok Zor</option>
-                                                </select>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <div class="mb-3">
-                                                <label for="estimatedDuration" class="form-label">Tahmini Süre (dakika)</label>
-                                                <input type="number" class="form-control" id="estimatedDuration" min="1">
-                                            </div>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <div class="mb-3">
-                                                <label for="totalDistance" class="form-label">Toplam Mesafe (km)</label>
-                                                <input type="number" class="form-control" id="totalDistance" min="0" step="0.1">
-                                            </div>
-                                        </div>
-                                    </div>
-                                    
-                                    <div class="mb-3">
-                                        <label for="isCircular" class="form-label">
-                                            <input type="checkbox" id="isCircular" class="form-check-input me-2">
-                                            Dairesel Rota (başlangıç ve bitiş aynı nokta)
-                                        </label>
-                                    </div>
-                                    
-                                    <div class="mb-3">
-                                        <label for="tags" class="form-label">Etiketler</label>
-                                        <input type="text" class="form-control" id="tags" placeholder="Örn: doğa, tarih, fotoğraf (virgülle ayırın)">
-                                    </div>
-                                </form>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
-                                <button type="button" class="btn btn-primary" onclick="createNewRoute()">
-                                    <i class="fas fa-save me-2"></i>Rotayı Oluştur
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            `;
-            
-            // Remove existing modal if present
-            const existingModal = document.getElementById('createRouteModal');
-            if (existingModal) {
-                existingModal.remove();
-            }
-            
-            // Add modal to page
-            document.body.insertAdjacentHTML('beforeend', modalHtml);
-            
-            // Show modal
-            const modal = new bootstrap.Modal(document.getElementById('createRouteModal'));
-            modal.show();
-        }
-
-        // Create new route function
-        async function createNewRoute() {
-            // Get form data
-            const form = document.getElementById('createRouteForm');
-            const formData = new FormData(form);
-            
+        async function createAndEditRoute() {
             const routeData = {
-                name: document.getElementById('routeName').value.trim(),
-                description: document.getElementById('routeDescription').value.trim(),
-                route_type: document.getElementById('routeType').value,
-                difficulty_level: parseInt(document.getElementById('difficultyLevel').value),
-                estimated_duration: parseInt(document.getElementById('estimatedDuration').value) || 0,
-                total_distance: parseFloat(document.getElementById('totalDistance').value) || 0,
-                is_circular: document.getElementById('isCircular').checked,
-                tags: document.getElementById('tags').value.trim(),
+                name: 'Yeni Rota',
+                route_type: 'walking',
+                difficulty_level: 1,
                 is_active: true
             };
-            
-            // Validation
-            if (!routeData.name) {
-                showNotification('Rota adı zorunludur!', 'error');
-                return;
-            }
-            
-            if (!routeData.route_type) {
-                showNotification('Rota tipi seçiniz!', 'error');
-                return;
-            }
-            
-            if (!routeData.difficulty_level) {
-                showNotification('Zorluk seviyesi seçiniz!', 'error');
-                return;
-            }
-            
+
             try {
-                // Send to API
                 const response = await fetch('/api/admin/routes', {
                     method: 'POST',
                     headers: {
@@ -3251,25 +3120,13 @@
                     },
                     body: JSON.stringify(routeData)
                 });
-                
+
                 if (response.ok) {
                     const result = await response.json();
-                    
-                    // Close modal
-                    const modal = bootstrap.Modal.getInstance(document.getElementById('createRouteModal'));
-                    modal.hide();
-                    
-                    // Refresh routes list
-                    loadRoutes();
-                    
-                    showNotification('✅ Yeni rota başarıyla oluşturuldu!', 'success');
-                    
-                    // Optionally select the new route
-                    if (result.route && result.route.id) {
-                        setTimeout(() => {
-                            selectRoute(result.route.id);
-                        }, 1000);
-                    }
+                    await loadRoutes();
+                    selectRoute(result.id);
+                    editCurrentRoute();
+                    showNotification('✅ Yeni rota oluşturuldu', 'success');
                 } else {
                     const error = await response.json();
                     showNotification(`❌ Rota oluşturulamadı: ${error.message || 'Bilinmeyen hata'}`, 'error');
@@ -3487,6 +3344,11 @@
                                             <!-- Associated POIs will be loaded here -->
                                         </div>
                                     </div>
+                                </div>
+                                <div class="mt-3">
+                                    <button type="button" class="btn btn-primary" onclick="buildAndSaveRouteFromAssociatedPOIs()">
+                                        <i class="fas fa-route me-1"></i>Rota Hesapla
+                                    </button>
                                 </div>
                             </div>
                         </div>
@@ -3780,6 +3642,7 @@
                         });
                     }
                     console.log('Processed all POIs:', allPOIs.length);
+                    allPoisForAssociation = allPOIs.slice();
                 } else {
                     console.error('Failed to load POIs:', poisResponse.status);
                     throw new Error('POI\'ler yüklenemedi');
@@ -4241,37 +4104,79 @@
             const ids = Array.from(associatedPoiIdSet);
             if (ids.length < 2) { showNotification('Rota için en az 2 POI seçin', 'warning'); return; }
             try {
-                // Build polyline from associated POIs in current order
-                const ordered = ids.map(id => (allPoisForAssociation || []).find(p => getPoiId(p) === id)).filter(Boolean);
-                const coords = ordered.map(p => ({ lat: p.latitude || p.lat, lng: p.longitude || p.lng }));
-                // Distance (Haversine)
-                const R = 6371000; // meters
-                const toRad = d => d * Math.PI / 180;
+                // Build ordered waypoint list
+                const ordered = ids
+                    .map(id => (allPoisForAssociation || []).find(p => getPoiId(p) === id))
+                    .filter(Boolean);
+                const waypoints = ordered.map((p, i) => ({
+                    lat: p.latitude || p.lat,
+                    lng: p.longitude || p.lng,
+                    name: p.name,
+                    order: i + 1
+                }));
+
+                let segments = [];
                 let totalMeters = 0;
-                for (let i = 1; i < coords.length; i++) {
-                    const a = coords[i-1], b = coords[i];
-                    const dLat = toRad(b.lat - a.lat);
-                    const dLon = toRad(b.lng - a.lng);
-                    const lat1 = toRad(a.lat), lat2 = toRad(b.lat);
-                    const h = Math.sin(dLat/2)**2 + Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;
-                    totalMeters += 2 * R * Math.asin(Math.sqrt(h));
+                let estimatedSeconds = 0;
+
+                try {
+                    // Request smart route so we follow the actual road network
+                    const smartResp = await fetch('/api/route/smart', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        credentials: 'include',
+                        body: JSON.stringify({ waypoints })
+                    });
+
+                    if (!smartResp.ok) throw new Error('smart route failed');
+                    const routeData = await smartResp.json();
+
+                    // Extract segments and stats from smart route response
+                    const segs = routeData?.route?.segments || [];
+                    segments = segs.map(seg => ({ coordinates: seg.coordinates || seg }));
+                    totalMeters = Math.round((routeData.route?.total_distance || routeData.total_distance || 0) * 1000);
+                    estimatedSeconds = Math.round((routeData.route?.estimated_time || routeData.estimated_time || 0) * 60);
+                } catch (smartErr) {
+                    console.warn('Smart routing failed, falling back to straight lines:', smartErr);
+
+                    // Fallback: simple straight-line polyline
+                    const coords = waypoints.map(wp => ({ lat: wp.lat, lng: wp.lng }));
+                    segments = [{ coordinates: coords }];
+
+                    // Haversine distance calculation
+                    const R = 6371000;
+                    const toRad = d => d * Math.PI / 180;
+                    for (let i = 1; i < coords.length; i++) {
+                        const a = coords[i - 1], b = coords[i];
+                        const dLat = toRad(b.lat - a.lat);
+                        const dLon = toRad(b.lng - a.lng);
+                        const lat1 = toRad(a.lat), lat2 = toRad(b.lat);
+                        const h = Math.sin(dLat/2)**2 + Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;
+                        totalMeters += 2 * R * Math.asin(Math.sqrt(h));
+                    }
+                    estimatedSeconds = Math.round(totalMeters / 1.2); // ~1.2 m/s walking speed
                 }
-                const estimatedSeconds = Math.round((totalMeters / 1.2)); // yürüyüş ~1.2 m/s varsayım
-                const segments = [{ coordinates: coords }];
-                const waypoints = ordered.map((p, i) => ({ name: p.name, latitude: p.latitude || p.lat, longitude: p.longitude || p.lng, order: i+1 }));
 
                 // Save geometry to backend
                 const headers = { 'Content-Type': 'application/json' };
                 if (csrfToken) headers['X-CSRFToken'] = csrfToken;
                 const resp = await fetch(`${apiBase}/admin/routes/${currentRoute.id}/geometry`, {
-                    method: 'POST', headers, credentials: 'include',
-                    body: JSON.stringify({ geometry: segments, total_distance: totalMeters, estimated_time: estimatedSeconds, waypoints })
+                    method: 'POST',
+                    headers,
+                    credentials: 'include',
+                    body: JSON.stringify({
+                        geometry: segments,
+                        total_distance: totalMeters,
+                        estimated_time: estimatedSeconds,
+                        waypoints
+                    })
                 });
                 if (!resp.ok) throw new Error('Geometri kaydedilemedi');
+
                 showNotification('Rota geometri kaydedildi', 'success');
                 await loadRoutes();
                 // Önizleme için vurgula
-                highlightRouteOnMap(allRoutes.find(r => getRouteId(r) === getRouteId(currentRoute)) || currentRoute);
+                await showSelectedRouteOnMap(allRoutes.find(r => getRouteId(r) === getRouteId(currentRoute)) || currentRoute);
             } catch (e) {
                 console.error('Build route error:', e);
                 showNotification('Rota oluşturma/kaydetme hatası', 'error');

--- a/test_route_service.py
+++ b/test_route_service.py
@@ -249,8 +249,42 @@ class TestRouteService(unittest.TestCase):
     def test_associate_pois_empty_list(self):
         """Associate POIs with empty list test"""
         result = self.service.associate_pois(1, [])
-        
+
         self.assertTrue(result)
+
+    @patch.object(RouteService, 'save_route_geometry', return_value=True)
+    def test_associate_pois_with_geometry_calls_save(self, mock_save):
+        """associate_pois should save geometry when provided"""
+        poi_associations = [
+            {
+                'poi_id': 1,
+                'order_in_route': 1,
+                'is_mandatory': True,
+                'estimated_time_at_poi': 20
+            }
+        ]
+
+        geometry = [
+            {
+                'coordinates': [
+                    {'lat': 38.0, 'lng': 34.0},
+                    {'lat': 38.1, 'lng': 34.1}
+                ]
+            }
+        ]
+
+        with patch.object(self.service, '_execute_query', side_effect=[1, 1]):
+            result = self.service.associate_pois(
+                1,
+                poi_associations,
+                geometry_segments=geometry,
+                total_distance=1000,
+                estimated_time=600,
+                waypoints=[{'lat': 38.0, 'lng': 34.0}, {'lat': 38.1, 'lng': 34.1}]
+            )
+
+        self.assertTrue(result)
+        mock_save.assert_called_once()
     
     def test_search_routes(self):
         """Search routes test"""
@@ -480,12 +514,53 @@ class TestRouteService(unittest.TestCase):
         
         with patch.object(self.service, '_execute_query', return_value=[]) as mock_query:
             self.service.search_routes(dangerous_input)
-            
+
             # Verify the query was called with parameterized input
             mock_query.assert_called_once()
             args, kwargs = mock_query.call_args
             # The dangerous input should be passed as a parameter, not concatenated
             self.assertIn('%', args[0])  # Should contain parameter placeholders
+
+    @patch('route_service.ElevationService')
+    def test_save_route_geometry_generates_elevation(self, mock_elev):
+        """save_route_geometry should generate elevation profile"""
+        mock_instance = mock_elev.return_value
+        mock_profile = {
+            'points': [],
+            'stats': {
+                'min_elevation': 100,
+                'max_elevation': 150,
+                'elevation_gain': 50,
+                'total_ascent': 50,
+                'total_descent': 0
+            },
+            'total_distance': 1000,
+            'point_count': 2,
+            'resolution': 10
+        }
+        mock_instance.generate_elevation_profile_from_geometry.return_value = mock_profile
+
+        geometry_segments = [
+            {'coordinates': [
+                {'lat': 38.0, 'lng': 34.0},
+                {'lat': 38.1, 'lng': 34.1}
+            ]}
+        ]
+
+        with patch.object(self.service, '_execute_query', side_effect=[1, {'has_geometry': True}]) as mock_exec:
+            result = self.service.save_route_geometry(
+                1,
+                geometry_segments,
+                total_distance=1000,
+                estimated_time=600,
+                waypoints=[{'lat': 38.0, 'lng': 34.0}, {'lat': 38.1, 'lng': 34.1}]
+            )
+
+            self.assertTrue(result)
+            mock_elev.assert_called_once()
+            mock_instance.generate_elevation_profile_from_geometry.assert_called_once()
+            first_call = mock_exec.call_args_list[0]
+            self.assertIn('elevation_profile', first_call[0][0])
 
 
 class TestRouteServiceIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add **Rota Hesapla** button to route management page to build and persist routes from associated POIs
- posting geometry saves distance, time and elevation profile for static routes
- fix undefined POI list reference when constructing routes from associated points
- use existing `showSelectedRouteOnMap` helper instead of removed `highlightRouteOnMap`
- persist smart-route geometry and stats when saving routes so elevation charts remain accurate
- open route editor directly when creating a new route instead of showing a popup

## Testing
- `pytest test_route_service.py::TestRouteService::test_save_route_geometry_generates_elevation -q`
- `pytest test_route_service.py::TestRouteService::test_associate_pois_with_geometry_calls_save -q`
- `POI_SESSION_SECRET_KEY=abcdefghijklmnopqrstuvwxyz1234567890abcd POI_ADMIN_PASSWORD_HASH='$2b$12$K/uoTR1GnndvrYJL/1Ddb.NsYManIeZDV4mQJzNw2K6JqqPiRWa1u' pytest test_api_endpoints.py::TestAdminRouteAPIEndpoints::test_admin_associate_pois_with_geometry -q`


------
https://chatgpt.com/codex/tasks/task_e_689f0f08a0e88320aa65e5ff8ba52f54