### PR TITLE
fix: load real elevation data in route manager

### DIFF
--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -1191,6 +1191,10 @@
             });
             routeLayers = {};
             console.log('Tüm rotalar haritadan kaldırıldı');
+
+            if (window.routeElevationChart) {
+                window.routeElevationChart.hideChart();
+            }
         }
 
         // POI'lerden dinamik rota oluştur
@@ -1239,9 +1243,26 @@
                             
                             // Haritayı rotaya odakla
                             map.fitBounds(layer.getBounds(), { padding: [50, 50] });
-                            
+
                             console.log('✅ POI-based rota oluşturuldu:', pois.length, 'POI');
                             showNotification(`${pois.length} POI ile dinamik rota oluşturuldu`, 'success');
+
+                            // Load elevation profile for POI-based route
+                            if (window.routeElevationChart) {
+                                if (route.elevation_profile && route.elevation_profile.points) {
+                                    await window.routeElevationChart.loadElevationProfile(route.elevation_profile);
+                                } else {
+                                    await window.routeElevationChart.loadRouteElevation({
+                                        pois: pois
+                                            .filter(poi => poi.latitude && poi.longitude)
+                                            .map(poi => ({
+                                                name: poi.name,
+                                                latitude: parseFloat(poi.latitude),
+                                                longitude: parseFloat(poi.longitude)
+                                            }))
+                                    });
+                                }
+                            }
                         } else {
                             console.warn('Yeterli POI koordinatı yok');
                             showNotification('Bu rotada yeterli POI koordinatı bulunamadı', 'warning');
@@ -1362,10 +1383,33 @@
                     if (layer) {
                         layer.addTo(map);
                         routeLayers[rid] = layer;
-                        
+
                         // Haritayı rotaya odakla
                         map.fitBounds(layer.getBounds(), { padding: [50, 50] });
-                        
+
+                        // Load elevation profile from route or available geometry data
+                        if (window.routeElevationChart) {
+                            if (route.elevation_profile && route.elevation_profile.points) {
+                                await window.routeElevationChart.loadElevationProfile(route.elevation_profile);
+                            } else if (geometry.type === 'LineString' && geometry.coordinates) {
+                                await window.routeElevationChart.loadRouteElevation({
+                                    geometry: geometry
+                                });
+                            } else if (geometry.geometry && geometry.geometry.type === 'LineString') {
+                                await window.routeElevationChart.loadRouteElevation({
+                                    geometry: geometry.geometry
+                                });
+                            } else if (geometry.waypoints && Array.isArray(geometry.waypoints) && geometry.waypoints.length > 0) {
+                                await window.routeElevationChart.loadRouteElevation({
+                                    pois: geometry.waypoints.map(wp => ({
+                                        latitude: wp.lat || wp.latitude,
+                                        longitude: wp.lng || wp.longitude,
+                                        name: wp.name || ''
+                                    }))
+                                });
+                            }
+                        }
+
                         console.log('✅ Rota haritaya eklendi:', route.name);
                     } else {
                         console.warn('Hiçbir geometri formatı işlenemedi:', geometry);
@@ -1499,6 +1543,11 @@
             }).addTo(map);
             // Layer for POI markers of the selected route
             poiMarkersLayer = L.layerGroup().addTo(map);
+
+            // Initialize elevation chart
+            if (window.ElevationChart) {
+                window.routeElevationChart = new ElevationChart('routeElevationChartContainer', map);
+            }
             
             // Force map size invalidation after a short delay
             setTimeout(() => {
@@ -1952,16 +2001,16 @@
             // Add CSS for route detail view
             addRouteDetailStyles();
             
-            // Create elevation chart for route manager
+            // Load elevation chart for route manager
             if (window.ElevationChart && route) {
                 setTimeout(async () => {
-                    if (window.routeElevationChart) {
-                        window.routeElevationChart.destroy();
+                    if (!window.routeElevationChart) {
+                        window.routeElevationChart = new ElevationChart('routeElevationChartContainer', map);
                     }
-                    window.routeElevationChart = new ElevationChart('routeElevationChartContainer', routeMap);
-                    
-                    // Load route data for elevation
-                    if (route.geometry) {
+
+                    if (route.elevation_profile && route.elevation_profile.points) {
+                        await window.routeElevationChart.loadElevationProfile(route.elevation_profile);
+                    } else if (route.geometry) {
                         await window.routeElevationChart.loadRouteElevation({
                             geometry: route.geometry
                         });


### PR DESCRIPTION
## Summary
- display stored elevation profiles when available
- fall back to generating elevation data only when needed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a07f3628e88320bd980210b9568ce8