### PR TITLE
Restore route manager actions after edit

### DIFF
--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -1473,6 +1473,7 @@
         let associatedPoiOrderedIds = [];
         let allPoisForAssociation = [];
         let csrfToken = null;
+        let defaultWorkspaceActionsHTML = '';
         
         // Rate limiting için
         let lastLoadTime = 0;
@@ -1514,6 +1515,8 @@
             loadRoutes();
             setupEventListeners();
             setupResizableMap();
+            const workspaceActionsElem = document.getElementById('workspaceActions');
+            defaultWorkspaceActionsHTML = workspaceActionsElem.innerHTML;
             // Fetch CSRF token for admin POSTs
             fetch('/auth/csrf-token', { credentials: 'include' })
                 .then(r => r.ok ? r.json() : null)
@@ -1947,6 +1950,7 @@
             }
 
             workspaceTitle.textContent = routeDetails.name;
+            workspaceActions.innerHTML = defaultWorkspaceActionsHTML;
             workspaceActions.style.display = 'flex';
 
             workspaceContent.innerHTML = `


### PR DESCRIPTION
## Summary
- Reset workspace action buttons to original set after saving or cancelling edits in route manager
- Capture default action markup on load for reliable restoration

## Testing
- `make quick` *(fails: Ruff check found 245 issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a085ed36a083208876b6b6f1b98b64