### PR TITLE
Add shared map layer control across project

### DIFF
--- a/basic_map_test.html
+++ b/basic_map_test.html
@@ -25,10 +25,10 @@
         Harita yükleniyor...
     </div>
 
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script>
         const statusDiv = document.getElementById('status');
-        
+
         function updateStatus(message, color = 'black') {
             statusDiv.innerHTML = message;
             statusDiv.style.color = color;
@@ -38,13 +38,10 @@
             // Haritayı oluştur
             updateStatus('Harita oluşturuluyor...', 'blue');
             const map = L.map('map').setView([38.632, 34.912], 13);
-            
-            // OpenStreetMap katmanını ekle
-            updateStatus('OpenStreetMap katmanı ekleniyor...', 'blue');
-            const osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors',
-                maxZoom: 19
-            });
+
+            // Harita katmanlarını ekle
+            const baseLayers = addBaseLayers(map);
+            const osmLayer = baseLayers["🗺️ OpenStreetMap"];
 
             // Event listener'lar
             osmLayer.on('loading', function() {
@@ -59,9 +56,6 @@
                 updateStatus('❌ Harita yükleme hatası: ' + error.error, 'red');
                 console.error('Tile error:', error);
             });
-
-            // Katmanı haritaya ekle
-            osmLayer.addTo(map);
 
             // Test marker'ı ekle
             const marker = L.marker([38.632, 34.912]).addTo(map);

--- a/elevation-chart-test.html
+++ b/elevation-chart-test.html
@@ -70,6 +70,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/elevation-chart.js"></script>
     <script>
         let map;
@@ -78,10 +79,8 @@
         // Initialize map
         function initMap() {
             map = L.map('mapContainer').setView([38.6436, 34.8128], 12);
-            
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors'
-            }).addTo(map);
+
+            addBaseLayers(map);
             
             // Initialize elevation chart
             elevationChart = new ElevationChart('elevationChartContainer', map);

--- a/file_import_manager.html
+++ b/file_import_manager.html
@@ -310,6 +310,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="static/js/api-client.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/enhanced-map-manager.js"></script>
     <script src="static/js/navigation-manager.js"></script>
     <script>

--- a/poi_manager_enhanced.html
+++ b/poi_manager_enhanced.html
@@ -1970,6 +1970,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/rate-limiter.js"></script>
     <script>
         // Rate limiting bilgilendirme mesajı
@@ -2023,9 +2024,7 @@
             async initializeMap() {
                 this.map = L.map('map').setView([38.6431, 34.8331], 11);
 
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: '© OpenStreetMap contributors'
-                }).addTo(this.map);
+                addBaseLayers(this.map);
 
                 // Add double-click handler for creating new POIs
                 this.map.on('dblclick', (e) => {

--- a/poi_manager_ui.html
+++ b/poi_manager_ui.html
@@ -1169,6 +1169,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <script>
         const apiBase = '/api';
@@ -1348,39 +1349,7 @@
         function initMap() {
             map = L.map('map').setView([38.6322, 34.9115], 16); // Ürgüp merkezi
 
-            // Farklı harita katmanları tanımla
-            const baseLayers = {
-                "🗺️ OpenStreetMap": L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: '© OpenStreetMap contributors',
-                    maxZoom: 20
-                }),
-
-                "🛰️ Uydu Görüntüsü": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-                    attribution: '© Esri, Maxar, Earthstar Geographics',
-                    maxZoom: 19
-                }),
-
-                "🏔️ Topografik": L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-                    attribution: '© OpenTopoMap (CC-BY-SA)',
-                    maxZoom: 17
-                }),
-
-                "🎨 CartoDB Positron": L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-                    attribution: '© OpenStreetMap © CartoDB',
-                    maxZoom: 19
-                }),
-
-                "🌙 CartoDB Dark": L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-                    attribution: '© OpenStreetMap © CartoDB',
-                    maxZoom: 19
-                })
-            };
-
-            // Varsayılan katmanı ekle
-            baseLayers["🗺️ OpenStreetMap"].addTo(map);
-
-            // Katman kontrolünü ekle
-            L.control.layers(baseLayers).addTo(map);
+            addBaseLayers(map);
 
             // Haritaya çift tıklama ile POI ekleme
             map.on('dblclick', function (e) {
@@ -4964,9 +4933,7 @@
 
                 routePreviewMap = L.map('routePreviewMap').setView([38.6431, 34.8288], 13);
 
-                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                    attribution: '© OpenStreetMap contributors'
-                }).addTo(routePreviewMap);
+                addBaseLayers(routePreviewMap);
 
                 // Harita yüklendikten sonra boyutunu ayarla
                 setTimeout(() => {

--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -596,6 +596,7 @@
     <script src="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.js"></script>
     <script src="static/js/rate-limiter.js"></script>
     <script src="static/js/elevation-chart.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/poi_recommendation_system.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.css" />
 </body>

--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -1169,7 +1169,8 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>  
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/rate-limiter.js"></script>
     <script src="static/js/elevation-chart.js"></script>
     <script src="static/js/api-client.js"></script>
@@ -1574,10 +1575,8 @@
             
             map = L.map('routeMap').setView([38.7312, 34.4547], 10);
             console.log('Map object created:', map);
-            
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors'
-            }).addTo(map);
+
+            addBaseLayers(map);
             // Layer for POI markers of the selected route
             poiMarkersLayer = L.layerGroup().addTo(map);
 

--- a/static/js/enhanced-map-manager.js
+++ b/static/js/enhanced-map-manager.js
@@ -87,11 +87,8 @@ class EnhancedMapManager {
             attributionControl: true
         });
 
-        // Add base tile layer
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '© OpenStreetMap contributors',
-            maxZoom: this.options.maxZoom
-        }).addTo(this.map);
+        // Add base tile layers with control
+        addBaseLayers(this.map);
 
         // Wait for map to be ready
         return new Promise((resolve) => {

--- a/static/js/map-layer-control.js
+++ b/static/js/map-layer-control.js
@@ -1,0 +1,28 @@
+function addBaseLayers(map) {
+    const baseLayers = {
+        "🗺️ OpenStreetMap": L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors',
+            maxZoom: 20
+        }),
+        "🛰️ Uydu Görüntüsü": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
+            attribution: '© Esri, Maxar, Earthstar Geographics',
+            maxZoom: 19
+        }),
+        "🏔️ Topografik": L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenTopoMap (CC-BY-SA)',
+            maxZoom: 17
+        }),
+        "🎨 CartoDB Positron": L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+            attribution: '© OpenStreetMap © CartoDB',
+            maxZoom: 19
+        }),
+        "🌙 CartoDB Dark": L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+            attribution: '© OpenStreetMap © CartoDB',
+            maxZoom: 19
+        })
+    };
+
+    baseLayers["🗺️ OpenStreetMap"].addTo(map);
+    L.control.layers(baseLayers).addTo(map);
+    return baseLayers;
+}

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4485,11 +4485,8 @@ async function initializePredefinedMap() {
                 attributionControl: true
             });
             
-            // Add tile layer
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© OpenStreetMap contributors',
-                maxZoom: 18
-            }).addTo(predefinedMap);
+            // Add base layers
+            addBaseLayers(predefinedMap);
             
             console.log('✅ Predefined map created successfully');
         }
@@ -6744,17 +6741,8 @@ async function performMainMapInitialization() {
             markerZoomAnimation: true // Enable marker zoom animations
         }).setView([38.632, 34.912], 13);
         
-        // Add optimized tile layer
-        const tileLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '© OpenStreetMap contributors',
-            maxZoom: 19,
-            subdomains: ['a', 'b', 'c'], // Use multiple subdomains for faster loading
-            keepBuffer: 2, // Keep tiles in buffer for smoother panning
-            updateWhenZooming: false, // Don't update tiles while zooming
-            updateWhenIdle: true // Update tiles when interaction stops
-        });
-        
-        tileLayer.addTo(map);
+        // Add base layers
+        addBaseLayers(map);
         
         // Clear markers array
         markers = [];
@@ -6925,10 +6913,8 @@ async function initializeRoutePreviewMap(mapId, routeId, pois) {
             attributionControl: false
         });
         
-        // Add tile layer
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: ''
-        }).addTo(previewMap);
+        // Add base layers
+        addBaseLayers(previewMap);
         
         // Store the map
         previewMaps.set(mapId, previewMap);
@@ -8572,10 +8558,8 @@ async function initializeEmptyMap() {
         maxBoundsViscosity: 0.0
     }).setView([38.632, 34.912], 13);
 
-    // Add tile layer
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '© OpenStreetMap contributors'
-    }).addTo(map);
+    // Add base layers
+    addBaseLayers(map);
 
     // Add map controls
     if (L.Control.Fullscreen) {
@@ -8641,10 +8625,8 @@ async function initializeMap(recommendationData) {
         maxBoundsViscosity: 0.0
     }).setView([38.632, 34.912], 13);
 
-    // Add tile layer
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '© OpenStreetMap contributors'
-    }).addTo(map);
+    // Add base layers
+    addBaseLayers(map);
 
     // Add map controls
     if (L.Control.Fullscreen) {

--- a/test-runner.html
+++ b/test-runner.html
@@ -320,7 +320,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
-    
+    <script src="static/js/map-layer-control.js"></script>
+
     <!-- Application Scripts -->
     <script src="static/js/enhanced-map-manager.js"></script>
     <script>

--- a/test_map_layers.html
+++ b/test_map_layers.html
@@ -39,6 +39,7 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script>
         // Haritayı başlat (Ürgüp merkezi)
         const map = L.map('map').setView([38.632, 34.912], 13);
@@ -53,48 +54,8 @@
             statusLog.appendChild(div);
         }
 
-        // Harita katmanları tanımla
-        const baseLayers = {
-            "🗺️ OpenStreetMap": L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-                maxZoom: 19,
-                subdomains: ['a', 'b', 'c']
-            }),
-
-            "🛰️ Esri Satellite": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-                attribution: '© Esri, Maxar, Earthstar Geographics',
-                maxZoom: 19
-            }),
-
-            "🏔️ OpenTopoMap": L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
-                maxZoom: 17,
-                subdomains: ['a', 'b', 'c']
-            }),
-
-            "🎨 CartoDB Positron": L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-                maxZoom: 20,
-                subdomains: 'abcd'
-            }),
-
-            "🌙 CartoDB Dark": L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-                maxZoom: 20,
-                subdomains: 'abcd'
-            }),
-
-            "🌍 Esri World Street": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}', {
-                attribution: '© <a href="https://www.esri.com/">Esri</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-                maxZoom: 19
-            }),
-
-            "🗺️ OSM Humanitarian": L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a>',
-                maxZoom: 19,
-                subdomains: ['a', 'b']
-            })
-        };
+        // Harita katmanlarını ekle
+        const baseLayers = addBaseLayers(map);
 
         // Her katman için event listener'lar ekle
         Object.keys(baseLayers).forEach(layerName => {
@@ -118,15 +79,8 @@
             });
         });
 
-        // Varsayılan katmanı ekle
-        baseLayers["🗺️ OpenStreetMap"].addTo(map);
+        // Varsayılan katman logu
         addStatus("Varsayılan katman (OpenStreetMap) eklendi", 'success');
-
-        // Katman kontrolünü ekle
-        const layerControl = L.control.layers(baseLayers, null, {
-            position: 'topright',
-            collapsed: false  // Test için açık bırak
-        }).addTo(map);
 
         // Katman değişikliklerini dinle
         map.on('baselayerchange', function(e) {

--- a/working_map_test.html
+++ b/working_map_test.html
@@ -36,13 +36,14 @@
     </div>
 
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="static/js/map-layer-control.js"></script>
     <script>
         // Haritayı başlat (Ürgüp merkezi)
         const map = L.map('map').setView([38.632, 34.912], 13);
-        
+
         // Status log elementi
         const statusLog = document.getElementById('status-log');
-        
+
         function addStatus(message, type = 'info') {
             const div = document.createElement('div');
             div.className = `status ${type}`;
@@ -50,59 +51,28 @@
             statusLog.appendChild(div);
         }
 
-        // Çalışan harita katmanları (test edilmiş URL'ler)
-        const baseLayers = {
-            "🗺️ OpenStreetMap": L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-                maxZoom: 19,
-                subdomains: ['a', 'b', 'c']
-            }),
-
-            "🎨 CartoDB Positron": L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-                maxZoom: 19,
-                subdomains: ['a', 'b', 'c', 'd']
-            }),
-
-            "🌙 CartoDB Dark": L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
-                attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors © <a href="https://carto.com/attributions">CARTO</a>',
-                maxZoom: 19,
-                subdomains: ['a', 'b', 'c', 'd']
-            }),
-
-            "🛰️ Esri Satellite": L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
-                attribution: '© <a href="https://www.esri.com/">Esri</a>, Maxar, Earthstar Geographics',
-                maxZoom: 18
-            })
-        };
+        // Harita katmanlarını ekle
+        const baseLayers = addBaseLayers(map);
 
         // Her katman için event listener'lar ekle
         Object.keys(baseLayers).forEach(layerName => {
             const layer = baseLayers[layerName];
-            
+
             layer.on('loading', function() {
                 addStatus(`${layerName} yükleniyor...`, 'warning');
             });
-            
+
             layer.on('load', function() {
                 addStatus(`${layerName} başarıyla yüklendi`, 'success');
             });
-            
+
             layer.on('tileerror', function(error) {
                 addStatus(`${layerName} yükleme hatası: ${error.error?.message || 'Bilinmeyen hata'}`, 'error');
                 console.error(`Tile error for ${layerName}:`, error);
             });
         });
 
-        // Varsayılan katmanı ekle
-        baseLayers["🗺️ OpenStreetMap"].addTo(map);
         addStatus("Varsayılan katman (OpenStreetMap) eklendi", 'success');
-
-        // Katman kontrolünü ekle
-        const layerControl = L.control.layers(baseLayers, null, {
-            position: 'topright',
-            collapsed: false  // Test için açık bırak
-        }).addTo(map);
 
         // Katman değişikliklerini dinle
         map.on('baselayerchange', function(e) {


### PR DESCRIPTION
## Summary
- create reusable map-layer-control script with OSM, satellite, topographic, and CartoDB variants
- integrate layer switcher into all main map pages and managers
- update recommendation and enhanced map managers to use shared layers

## Testing
- `pytest` *(fails: ModuleNotFoundError: psycopg2, flask, requests, werkzeug)*

------
https://chatgpt.com/codex/tasks/task_e_68a08892baec8320b3957b9ca958653f