### PR TITLE
Simplify predefined route selection

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -317,31 +317,6 @@
             </div>
         </div>
     </div>
-
-    <!-- Route Detail Modal -->
-    <div id="routeDetailModal" class="route-detail-modal">
-        <div class="route-detail-modal-content">
-            <div class="route-detail-modal-header">
-                <h3 class="route-detail-modal-title" id="routeDetailModalTitle">Rota Detayları</h3>
-                <button class="route-detail-modal-close" id="routeDetailModalClose" aria-label="Kapat">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-            <div class="route-detail-modal-body" id="routeDetailModalBody">
-                <div class="loading">
-                    <div class="loading__spinner"></div>
-                    <p class="loading__text">Rota detayları yükleniyor...</p>
-                </div>
-            </div>
-            <div class="route-detail-modal-footer">
-                <button class="route-select-btn" id="routeSelectBtn">
-                    <i class="fas fa-check"></i>
-                    Bu Rotayı Seç
-                </button>
-            </div>
-        </div>
-    </div>
-
     <!-- Route Context Menu -->
     <div id="routeContextMenu" class="route-context-menu">
         <div class="route-context-menu-header">

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5397,15 +5397,7 @@ function displayPredefinedRoutes(routes) {
     routesList.querySelectorAll('.route-card').forEach((card, index) => {
         card.addEventListener('click', async () => {
             const route = routes[index];
-            
-            // First display route on map
-            if (!predefinedMapInitialized) {
-                await initializePredefinedMap();
-            }
-            await displayRouteOnMap(route);
-            
-            // Then show route details modal
-            showRouteDetails(route);
+            await selectPredefinedRoute(route); // handles map rendering internally
         });
     });
 }


### PR DESCRIPTION
## Summary
- Delegate predefined route card clicks to `selectPredefinedRoute` for built-in map rendering
- Remove unused route detail modal markup

## Testing
- `python run_all_tests.py` *(fails: Backend Unit Tests - Route Service, API Core Functionality Tests, Authentication & Authorization Tests, End-to-End Test Scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b48ac1808320a01f4609324cfa01