### PR TITLE
Show predefined route details on selection

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -232,6 +232,7 @@
                         class="predefined-routes-description">
                         Uzmanlar tarafından önceden hazırlanmış rotalar arasından seçim yapın.
                         Her rota farklı deneyimler ve zorluk seviyeleri sunar.
+                        Rota kartına tıklayarak haritada görüntüleyin ve detaylarını inceleyin.
                     </p>
 
                     <!-- Route Filters -->

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5398,6 +5398,8 @@ function displayPredefinedRoutes(routes) {
         card.addEventListener('click', async () => {
             const route = routes[index];
             await selectPredefinedRoute(route); // handles map rendering internally
+            // Show route details after selecting the route
+            showPredefinedRouteDetailsPanel(window.currentSelectedRoute || route);
         });
     });
 }


### PR DESCRIPTION
## Summary
- Allow clicking a predefined route card to open the detailed route panel
- Clarify ready routes section text for viewing details

## Testing
- `make quick` *(fails: Ruff check failed)*
- `python tests/smoke.py` *(fails: connection refused to local API)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b6675fd883208ccc0151b6ea7f49