### PR TITLE
Fix POI details endpoint path

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5087,7 +5087,7 @@ async function loadDetailedPOIInfo(poiId, poiName) {
         showNotification('POI detayları yükleniyor...', 'info');
         
         // Fetch detailed POI data
-        const response = await fetch(`${apiBase}/pois/${poiId}`);
+        const response = await fetch(`${apiBase}/poi/${poiId}`);
         if (response.ok) {
             const poiData = await response.json();
             console.log('✅ POI details loaded:', poiData);


### PR DESCRIPTION
## Summary
- fix POI details modal to request the correct `/api/poi/<id>` endpoint

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68a0e064f3ac83209f6e5c7b5d2daeb7