### PR TITLE
Fix initialization errors and CSP for WebAssembly

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data: https://*; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self';">
     <title>Ürgüp POI Önerileri - Size Özel Yerler Keşfedin</title>
     <!-- Design System CSS -->
     <link rel="stylesheet" href="static/css/design-tokens.css">

--- a/static/js/performance-optimizations.js
+++ b/static/js/performance-optimizations.js
@@ -136,7 +136,7 @@ class OptimizedImageLoader {
 }
 
 // Performance monitoring
-class PerformanceMonitor {
+class RoutePerformanceMonitor {
     constructor() {
         this.metrics = {
             routeLoadTime: [],
@@ -180,9 +180,10 @@ class PerformanceMonitor {
 // Initialize optimized components
 const optimizedRouteLoader = new OptimizedRouteLoader();
 const optimizedImageLoader = new OptimizedImageLoader();
-const performanceMonitor = new PerformanceMonitor();
+const routePerformanceMonitor = new RoutePerformanceMonitor();
 
 // Export for global use
 window.OptimizedRouteLoader = OptimizedRouteLoader;
 window.OptimizedImageLoader = OptimizedImageLoader;
-window.PerformanceMonitor = PerformanceMonitor;
+window.RoutePerformanceMonitor = RoutePerformanceMonitor;
+window.routePerformanceMonitor = routePerformanceMonitor;

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -9949,6 +9949,36 @@ window.RouteContextMenu = RouteContextMenu;
 // Close the commented duplicate event listener section
 */
 
+function initializeApp() {
+    console.log('🔧 Initializing application components...');
+
+    if (typeof initializeTouchSupport === 'function') {
+        try {
+            initializeTouchSupport();
+        } catch (err) {
+            console.error('Touch support initialization failed:', err);
+        }
+    }
+
+    if (typeof initializeRouteTabs === 'function') {
+        try {
+            initializeRouteTabs();
+        } catch (err) {
+            console.error('Route tabs initialization failed:', err);
+        }
+    }
+
+    if (typeof initializeMainMap === 'function') {
+        try {
+            initializeMainMap();
+        } catch (err) {
+            console.error('Main map initialization failed:', err);
+        }
+    }
+
+    console.log('✅ Application components initialized');
+}
+
 // Initialize the application when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
     console.log('🚀 DOM loaded, initializing POI recommendation system...');


### PR DESCRIPTION
## Summary
- allow WebAssembly by permitting `unsafe-eval` in CSP
- avoid `PerformanceMonitor` name collision by introducing `RoutePerformanceMonitor`
- add `initializeApp` bootstrapper to set up touch, tabs and map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a0e9c741408320af574565e3894638