### PR TITLE
fix: handle category fetch errors and remove unused model-viewer

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -18,8 +18,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
-    
+
     <!-- Touch Optimizations -->
     <script src="static/js/touch-optimizations.js"></script>
     

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -140,8 +140,14 @@ async function loadCategories() {
     try {
         console.log('📋 Kategoriler API\'den yükleniyor...');
         const response = await fetch(`${apiBase}/categories`);
-        
+
         if (response.ok) {
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) {
+                console.warn('⚠️ Beklenmeyen içerik türü alındı:', contentType);
+                return false;
+            }
+
             const categories = await response.json();
             console.log('✅ Kategoriler yüklendi:', categories);
             
@@ -168,7 +174,7 @@ async function loadCategories() {
             console.log('✅ Kategori verileri güncellendi:', categoryData);
             return true;
         } else {
-            console.warn('⚠️ Kategoriler yüklenemedi, fallback kullanılacak');
+            console.warn(`⚠️ Kategoriler yüklenemedi, fallback kullanılacak (status: ${response.status})`);
             return false;
         }
     } catch (error) {


### PR DESCRIPTION
## Summary
- remove unused `@google/model-viewer` to eliminate WebAssembly CSP violations
- guard category loading against non-JSON responses and log status for fallback use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a18e075a588320b09dc07ba5a0b462