### PR TITLE
fix: restore map interactivity for predefined routes

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4951,7 +4951,17 @@ async function displayRouteOnMap(route) {
             visibility: mapContainer.style.visibility
         });
     }
-    
+
+    // Ensure all map interaction handlers are enabled
+    if (predefinedMap) {
+        predefinedMap.dragging.enable();
+        predefinedMap.touchZoom.enable();
+        predefinedMap.scrollWheelZoom.enable();
+        predefinedMap.doubleClickZoom.enable();
+        predefinedMap.boxZoom.enable();
+        predefinedMap.keyboard.enable();
+    }
+
     try {
         // Clear existing route layers
         clearPredefinedMapContent();


### PR DESCRIPTION
## Summary
- Ensure Leaflet map interactions are re-enabled after displaying a predefined route

## Testing
- `pytest` *(fails: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a19f408ce48320a08bcb34d63552ac