### PR TITLE
Fix predefined route map interactivity

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4950,6 +4950,8 @@ async function displayRouteOnMap(route) {
             display: mapContainer.style.display,
             visibility: mapContainer.style.visibility
         });
+        // Ensure container can receive pointer events
+        mapContainer.style.pointerEvents = 'auto';
     }
 
     // Ensure all map interaction handlers are enabled
@@ -5824,8 +5826,6 @@ function displayPredefinedRoutes(routes) {
             
             try {
                 await selectPredefinedRoute(route); // handles map rendering internally
-                // Show route details after selecting the route
-                showPredefinedRouteDetailsPanel(window.currentSelectedRoute || route);
             } catch (error) {
                 console.error('Error selecting route:', error);
             } finally {


### PR DESCRIPTION
## Summary
- ensure predefined route map container accepts pointer events
- avoid opening route details panel automatically when selecting a predefined route

## Testing
- `python run_all_tests.py` *(fails: Backend Unit Tests - Route Service, API Core Functionality Tests, Authentication & Authorization Tests, End-to-End Test Scenarios)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a21101e083208fe74a7d7db1f808