### PR TITLE
Fix frozen map after showing predefined routes

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4936,12 +4936,20 @@ async function displayRouteOnMap(route) {
         layersCount: predefinedMapLayers.length
     });
     
-    // Ensure map container is visible and invalidate size for proper rendering
+    // Ensure map container is visible and ready for interaction
     const mapContainer = document.getElementById('predefinedRoutesMap');
+    const loadingElement = document.getElementById('predefinedMapLoading');
     if (mapContainer) {
         mapContainer.style.display = 'block';
         mapContainer.style.visibility = 'visible';
         mapContainer.style.opacity = '1';
+        // If a loading overlay is present, hide it and restore pointer events
+        if (loadingElement) {
+            loadingElement.style.display = 'none';
+        }
+        mapContainer.classList.remove('loading');
+        mapContainer.classList.add('loaded');
+        mapContainer.style.pointerEvents = 'auto';
         predefinedMap.invalidateSize();
         console.log('🔄 Map container visibility and size refreshed');
         console.log('🔍 Map container dimensions:', {


### PR DESCRIPTION
## Summary
- Ensure predefined routes map is usable after loading by hiding any lingering loading overlay and re-enabling pointer events.
- Restore map interaction classes once a route is rendered.

## Testing
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a662e0b88320b541e59031419e26