### PR TITLE
Fix frozen predefined routes map by enabling interactions

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4871,12 +4871,23 @@ async function initializePredefinedMap() {
                 center: [38.6436, 34.8128], // Ürgüp center
                 zoom: 12,
                 zoomControl: true,
-                attributionControl: true
+                attributionControl: true,
+                scrollWheelZoom: true,
+                doubleClickZoom: true,
+                touchZoom: true,
+                dragging: true,
+                tap: true,
+                tapTolerance: 15,
+                preferCanvas: true,
+                renderer: L.canvas(),
+                zoomAnimation: true,
+                fadeAnimation: true,
+                markerZoomAnimation: true
             });
-            
+
             // Add base layers
             addBaseLayers(predefinedMap);
-            
+
             console.log('✅ Predefined map created successfully');
         }
         


### PR DESCRIPTION
## Summary
- Ensure predefined routes map uses the same interactive options as the recommendations map
- Enable zoom/drag features and canvas rendering for smoother predefined route display

## Testing
- `pytest` *(fails: No module named 'psycopg2', 'flask', 'requests', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a662e0b88320b541e59031419e26