### PR TITLE
Remove loading overlay that blocked predefined routes map

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4843,6 +4843,21 @@ let predefinedMap = null;
 let predefinedMapLayers = [];
 let predefinedMapInitialized = false;
 
+// Fully clear loading overlay and restore interactions
+function finalizePredefinedMapLoading() {
+    const mapContainer = document.getElementById('predefinedRoutesMap');
+    const loadingElement = document.getElementById('predefinedMapLoading');
+
+    if (loadingElement && loadingElement.parentNode) {
+        loadingElement.parentNode.removeChild(loadingElement);
+    }
+    if (mapContainer) {
+        mapContainer.classList.remove('loading');
+        mapContainer.classList.add('loaded');
+        mapContainer.style.pointerEvents = 'auto';
+    }
+}
+
 // Map initialization state management
 let mapInitializationPromise = null;
 let mapInitialized = false;
@@ -4871,12 +4886,23 @@ async function initializePredefinedMap() {
                 center: [38.6436, 34.8128], // Ürgüp center
                 zoom: 12,
                 zoomControl: true,
-                attributionControl: true
+                attributionControl: true,
+                scrollWheelZoom: true,
+                doubleClickZoom: true,
+                touchZoom: true,
+                dragging: true,
+                tap: true,
+                tapTolerance: 15,
+                preferCanvas: true,
+                renderer: L.canvas(),
+                zoomAnimation: true,
+                fadeAnimation: true,
+                markerZoomAnimation: true
             });
-            
+
             // Add base layers
             addBaseLayers(predefinedMap);
-            
+
             console.log('✅ Predefined map created successfully');
         }
         
@@ -4886,12 +4912,8 @@ async function initializePredefinedMap() {
         
         // Hide loading state
         addTimeout(() => {
-            if (loadingElement) {
-                loadingElement.style.display = 'none';
-            }
-            mapContainer.classList.remove('loading');
-            mapContainer.classList.add('loaded');
-            
+            finalizePredefinedMapLoading();
+
             // Invalidate size to ensure proper rendering
             if (predefinedMap) {
                 predefinedMap.invalidateSize();
@@ -4902,13 +4924,10 @@ async function initializePredefinedMap() {
         
     } catch (error) {
         console.error('❌ Error initializing predefined map:', error);
-        
+
         // Hide loading state on error
-        if (loadingElement) {
-            loadingElement.style.display = 'none';
-        }
-        mapContainer.classList.remove('loading');
-        
+        finalizePredefinedMapLoading();
+
         return false;
     }
 }
@@ -4935,13 +4954,14 @@ async function displayRouteOnMap(route) {
         mapInitialized: predefinedMapInitialized,
         layersCount: predefinedMapLayers.length
     });
-    
+
     // Ensure map container is visible and invalidate size for proper rendering
     const mapContainer = document.getElementById('predefinedRoutesMap');
     if (mapContainer) {
         mapContainer.style.display = 'block';
         mapContainer.style.visibility = 'visible';
         mapContainer.style.opacity = '1';
+        finalizePredefinedMapLoading();
         predefinedMap.invalidateSize();
         console.log('🔄 Map container visibility and size refreshed');
         console.log('🔍 Map container dimensions:', {


### PR DESCRIPTION
## Summary
- Strip out `predefinedMapLoading` overlay and re-enable pointer events to prevent predefined routes map from freezing
- Ensure map container finalized after initialization and when displaying routes

## Testing
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a662e0b88320b541e59031419e26