### PR TITLE
Remove redundant route notifications

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -3644,7 +3644,6 @@ async function addNavigationToRoute(route) {
                 const distanceKm = (distance / 1000).toFixed(1);
                 
                 if (distance < 100) { // Less than 100 meters
-                    showNotification('🎯 Zaten rota başlangıcında bulunuyorsunuz!', 'success');
                     return;
                 }
                 
@@ -6843,16 +6842,8 @@ async function selectPredefinedRoute(route) {
          console.log('🔎 Contains "patika"?', route.name?.toLowerCase().includes('patika'));
          console.log('🗺️ Full route object:', route);
          
-         // Simple approach: Always show single Google Maps button
-         showNotificationWithAction(
-             `✅ "${route.name}" rotası haritada gösteriliyor!`,
-             'success',
-             'Google Maps\'te Aç',
-             () => exportPredefinedRouteToGoogleMaps(route.id || route._id)
-         );
-         
-         // Add navigation route from current location to route start
-         addNavigationToRoute(route);
+        // Add navigation route from current location to route start
+        addNavigationToRoute(route);
     
     // Ensure predefined map is initialized with multiple attempts
     let mapInitAttempts = 0;
@@ -8034,9 +8025,6 @@ async function expandRoutePreview(routeId, routeName) {
         
         // Show route on predefined routes map (left side)
         await displayRouteOnMap(route);
-        
-        // Show notification
-        showNotification(`📍 "${routeName}" rotası haritada gösteriliyor`, 'success');
         
     } catch (error) {
         console.error('❌ Error expanding route preview:', error);


### PR DESCRIPTION
## Summary
- Remove success notifications that appeared when displaying predefined routes
- Stop showing popup when user is already at the route start

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68a220c02df88320ac6840806ac69530