### PR TITLE
Fix CSP for WebAssembly and route export error

### DIFF
--- a/auth_config.py
+++ b/auth_config.py
@@ -285,7 +285,7 @@ class AuthConfig:
             # Content Security Policy - restrictive but functional for the POI app
             'Content-Security-Policy': (
                 "default-src 'self'; "
-                "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
                 "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
                 "img-src 'self' data: blob: https://*.openstreetmap.org https://*.tile.openstreetmap.org https://*.opentopomap.org https://*.basemaps.cartocdn.com https://server.arcgisonline.com https://unpkg.com; "
                 "font-src 'self' https://cdnjs.cloudflare.com; "

--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data: https://*; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data: https://*; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self';">
     <title>Ürgüp POI Önerileri - Size Özel Yerler Keşfedin</title>
     <!-- Design System CSS -->
     <link rel="stylesheet" href="static/css/design-tokens.css">

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -1265,12 +1265,15 @@ class RouteDetailsPanel {
         console.log('🔍 Current route:', instance.currentRoute);
         console.log('🔍 Global currentSelectedRoute:', window.currentSelectedRoute);
         console.log('🔍 PredefinedRoutes array:', predefinedRoutes);
-        
+
         if (!instance.currentRoute) {
             console.log('❌ No current route in panel instance');
             showNotification('❌ Aktif rota bulunamadı', 'error');
             return;
         }
+
+        let waypoints = [];
+        let waypointNames = [];
 
         if (selectedPOIs.length === 0) {
             // Try to use route data from panel if available
@@ -1282,7 +1285,7 @@ class RouteDetailsPanel {
             } else if (instance.currentRoute && instance.currentRoute.is_predefined) {
                 // For predefined routes, use the current selected route data
                 console.log('🗺️ Predefined route detected in panel');
-                
+
                 // Try to find the route in predefinedRoutes global array
                 let routeToExport = null;
                 if (instance.currentRoute.predefined_route) {
@@ -1293,7 +1296,7 @@ class RouteDetailsPanel {
                     // Try to find by name in predefinedRoutes
                     routeToExport = predefinedRoutes.find(r => r.name === instance.currentRoute.route_name);
                 }
-                
+
                 if (routeToExport) {
                     console.log('🗺️ Found route to export:', routeToExport.name);
                     const routeId = routeToExport.id || routeToExport._id;
@@ -1312,34 +1315,31 @@ class RouteDetailsPanel {
                 // Fallback to default Cappadocia route
                 const defaultOrigin = '38.6427,34.8283'; // Göreme
                 const defaultDestination = '38.6436,34.8128'; // Ürgüp
-                
+
                 const url = `https://www.google.com/maps/dir/?api=1&origin=${defaultOrigin}&destination=${defaultDestination}&travelmode=walking&dir_action=navigate`;
-                
+
                 console.log('🗺️ No POIs or route data, opening default Cappadocia route');
                 window.open(url, '_blank');
                 showNotification('🗺️ Varsayılan Kapadokya rotası Google Maps\'te açıldı!', 'info');
                 return;
             }
-        }
+        } else {
+            // Add start location with name
+            if (startLocation) {
+                waypoints.push(`${startLocation.latitude},${startLocation.longitude}`);
+                waypointNames.push(encodeURIComponent(startLocation.name || 'Başlangıç Noktası'));
+            }
 
-        let waypoints = [];
-        let waypointNames = [];
+            // Add all POIs with names
+            selectedPOIs.forEach(poi => {
+                waypoints.push(`${poi.latitude},${poi.longitude}`);
+                waypointNames.push(encodeURIComponent(poi.name));
+            });
 
-        // Add start location with name
-        if (startLocation) {
-            waypoints.push(`${startLocation.latitude},${startLocation.longitude}`);
-            waypointNames.push(encodeURIComponent(startLocation.name || 'Başlangıç Noktası'));
-        }
-
-        // Add all POIs with names
-        selectedPOIs.forEach(poi => {
-            waypoints.push(`${poi.latitude},${poi.longitude}`);
-            waypointNames.push(encodeURIComponent(poi.name));
-        });
-
-        if (waypoints.length < 2) {
-            showNotification('❌ En az 2 nokta gerekli', 'error');
-            return;
+            if (waypoints.length < 2) {
+                showNotification('❌ En az 2 nokta gerekli', 'error');
+                return;
+            }
         }
 
         // Use simple coordinate-based approach for reliability


### PR DESCRIPTION
## Summary
- Allow WebAssembly modules by enabling `unsafe-eval`/`wasm-unsafe-eval` in CSP meta tag and server headers
- Prevent `waypoints` initialization error when exporting routes to Google Maps

## Testing
- `python -m py_compile auth_config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68a2253633108320b3cf4f278afd03d6