### PR TITLE
Fix CSP, route export error, and restore POI category icons

### DIFF
--- a/auth_config.py
+++ b/auth_config.py
@@ -285,7 +285,7 @@ class AuthConfig:
             # Content Security Policy - restrictive but functional for the POI app
             'Content-Security-Policy': (
                 "default-src 'self'; "
-                "script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
                 "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; "
                 "img-src 'self' data: blob: https://*.openstreetmap.org https://*.tile.openstreetmap.org https://*.opentopomap.org https://*.basemaps.cartocdn.com https://server.arcgisonline.com https://unpkg.com; "
                 "font-src 'self' https://cdnjs.cloudflare.com; "

--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data: https://*; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data: https://*; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self';">
     <title>Ürgüp POI Önerileri - Size Özel Yerler Keşfedin</title>
     <!-- Design System CSS -->
     <link rel="stylesheet" href="static/css/design-tokens.css">


### PR DESCRIPTION
## Summary
- Allow WebAssembly modules by enabling `unsafe-eval`/`wasm-unsafe-eval` in CSP meta tag and server headers
- Prevent `waypoints` initialization error when exporting routes to Google Maps
- Restore category-specific icons on POI markers

## Testing
- `python -m py_compile auth_config.py`
- `pytest -q` *(fails: ModuleNotFoundError: psycopg2, flask, requests, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a2253633108320b3cf4f278afd03d6