### PR TITLE
Fix overlapping map control buttons

### DIFF
--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -6184,7 +6184,7 @@ ute Preview Map Styles */
 
 .map-controls {
     position: absolute;
-    top: 10px;
+    top: 60px;
     right: 10px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Adjust map controls offset so that custom buttons no longer overlap the layer control on the map

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a22dcc60c48320a78584c27cab3d38