### PR TITLE
Add search filtering for predefined routes

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -402,7 +402,11 @@
                                 Her rota farklı deneyimler ve zorluk seviyeleri sunar.
                             </p>
                         </div>
-                        
+
+                        <div class="route-search">
+                            <input type="search" id="routeSearchInput" class="form-control" placeholder="Rota ara...">
+                        </div>
+
                         <!-- Quick Stats -->
                         <div class="routes-quick-stats" id="routesQuickStats">
                             <div class="quick-stat-item">

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -6151,6 +6151,20 @@ function clearRouteFilters() {
     displayPredefinedRoutes(filteredRoutes);
 }
 
+function setupRouteSearch() {
+    const searchInput = document.getElementById('routeSearchInput');
+    if (!searchInput) return;
+
+    searchInput.addEventListener('input', () => {
+        const query = searchInput.value.trim().toLowerCase();
+        filteredRoutes = predefinedRoutes.filter(route =>
+            route.name && route.name.toLowerCase().includes(query)
+        );
+        displayPredefinedRoutes(filteredRoutes);
+        updateRouteStats();
+    });
+}
+
 function showNoRoutesMessage(message = 'Seçilen kriterlere uygun rota bulunamadı.') {
     const routesList = document.getElementById('predefinedRoutesList');
     const noRoutesMessage = document.getElementById('noRoutesMessage');
@@ -10514,9 +10528,12 @@ function initializeEnhancedFilters() {
     if (applyFiltersBtn) {
         applyFiltersBtn.addEventListener('click', applyRouteFilters);
     }
-    
+
     // Update route counts
     updateRouteStats();
+
+    // Initialize route search
+    setupRouteSearch();
 }
 
 function initializeFilterChips() {


### PR DESCRIPTION
## Summary
- Add search input to predefined routes header
- Filter predefined route list by search query and update stats

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a2313ef94c8320956da7b367daf358