### PR TITLE
Enhance route cards with images and accessible metadata

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -570,9 +570,34 @@
                         </div>
 
                         <!-- Routes List -->
-                        <div id="predefinedRoutesList" class="predefined-routes-list">
-                            <!-- Routes will be loaded here dynamically -->
-                        </div>
+                        <template id="predefinedRouteCardTemplate">
+                            <div class="route-card">
+                                <div class="route-card-image">
+                                    <img src="" alt="">
+                                </div>
+                                <div class="route-card-content">
+                                    <div class="route-card-header">
+                                        <h3 class="route-card-title"></h3>
+                                        <p class="route-card-description"></p>
+                                    </div>
+                                    <div class="route-card-meta">
+                                        <div class="route-meta-item" aria-label="Süre">
+                                            <i class="fas fa-clock"></i>
+                                            <span></span>
+                                        </div>
+                                        <div class="route-meta-item" aria-label="Durak sayısı">
+                                            <i class="fas fa-map-marker-alt"></i>
+                                            <span></span>
+                                        </div>
+                                        <div class="route-meta-item" aria-label="Zorluk">
+                                            <i class="fas fa-mountain"></i>
+                                            <div class="difficulty-stars"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                        <div id="predefinedRoutesList" class="predefined-routes-list" aria-live="polite"></div>
                     </div>
 
                     <!-- No Routes Message -->

--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -6247,6 +6247,50 @@ ute Preview Map Styles */
     display: none;
 }
 
+/* === Predefined routes flex layout and card visuals === */
+.predefined-routes-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 24px;
+}
+
+.predefined-routes-list .route-card {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 300px;
+}
+
+.route-card-image {
+    width: 100%;
+    height: 180px;
+    background-size: cover;
+    background-position: center;
+    overflow: hidden;
+}
+
+.route-card-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.route-card-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.route-card-meta .route-meta-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.route-card-meta .route-meta-item i {
+    color: #667eea;
+}
+
 /* Route selection highlighting on map */
 .route-on-map {
     cursor: pointer;

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -6024,42 +6024,38 @@ function displayPredefinedRoutes(routes) {
 }
 
 function createRouteCard(route) {
-    const difficultyStars = createDifficultyStars(route.difficulty_level || 1);
+    const difficultyLevel = route.difficulty_level || 1;
+    const difficultyStars = createDifficultyStars(difficultyLevel);
     const duration = Math.round((route.estimated_duration || 0) / 60);
-    const distance = (route.total_distance || 0).toFixed(2);
-    const poiCount = route.poi_count || 0;
+    const stopCount = route.poi_count || (route.waypoints ? route.waypoints.length : 0);
+    const imageUrl = route.preview_image_url || route.image_url || 'https://via.placeholder.com/400x200?text=Rota';
     
     console.log('🏷️ Creating route card:', {
         name: route.name,
-        poiCount: poiCount,
+        stopCount: stopCount,
         rawPoiCount: route.poi_count
     });
-    
+
     return `
         <div class="route-card" data-route-id="${route.id}">
+            <div class="route-card-image">
+                <img src="${imageUrl}" alt="${route.name || 'Rota görseli'}">
+            </div>
             <div class="route-card-header">
                 <h3 class="route-card-title">${route.name || 'İsimsiz Rota'}</h3>
                 <p class="route-card-description">${route.description || 'Açıklama bulunmuyor.'}</p>
             </div>
             <div class="route-card-meta">
-                <div class="route-meta-item">
-                    <i class="fas fa-route"></i>
-                    <span>${getRouteTypeDisplayName(route.route_type)}</span>
-                </div>
-                <div class="route-meta-item">
-                    <i class="fas fa-clock"></i>
+                <div class="route-meta-item" aria-label="Süre: ${duration} saat">
+                    <i class="fas fa-clock" aria-hidden="true"></i>
                     <span>${duration} saat</span>
                 </div>
-                <div class="route-meta-item">
-                    <i class="fas fa-map-marker-alt"></i>
-                    <span>${distance} km</span>
+                <div class="route-meta-item" aria-label="Durak sayısı: ${stopCount}">
+                    <i class="fas fa-map-marker-alt" aria-hidden="true"></i>
+                    <span>${stopCount} durak</span>
                 </div>
-                <div class="route-meta-item">
-                    <i class="fas fa-map-marked-alt"></i>
-                    <span>${poiCount} yer</span>
-                </div>
-                <div class="route-meta-item route-difficulty">
-                    <i class="fas fa-mountain"></i>
+                <div class="route-meta-item route-difficulty" aria-label="Zorluk seviyesi: ${difficultyLevel}">
+                    <i class="fas fa-mountain" aria-hidden="true"></i>
                     <div class="difficulty-stars">${difficultyStars}</div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add route card template with image support and ARIA labels
- Render route cards with preview images and meta icons for duration, stop count, and difficulty
- Style predefined route list with flex layout and image sizing

## Testing
- `pytest test_frontend_functionality.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2328824a88320a9cb34fd10d4a1f4