### PR TITLE
Add mobile bottom sheet for route filters

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -431,18 +431,18 @@
                     </div>
 
                     <!-- Enhanced Route Filters -->
+                    <button class="filters-open-btn" id="openFiltersBtn">Filtreleri Aç</button>
                     <div class="route-filters-enhanced">
-                        <div class="filters-header">
-                            <h3 class="filters-title">
-                                <i class="fas fa-sliders-h"></i>
-                                Filtreler
-                            </h3>
-                            <button class="filters-toggle-btn" id="filtersToggleBtn">
-                                <i class="fas fa-chevron-down"></i>
-                            </button>
-                        </div>
-                        
                         <div class="filters-content" id="filtersContent">
+                            <div class="filters-header">
+                                <h3 class="filters-title">
+                                    <i class="fas fa-sliders-h"></i>
+                                    Filtreler
+                                </h3>
+                                <button class="filters-toggle-btn" id="filtersToggleBtn">
+                                    <i class="fas fa-chevron-down"></i>
+                                </button>
+                            </div>
                             <div class="filter-chips-container">
                                 <div class="filter-chip-group">
                                     <label class="filter-chip-label">Rota Tipi</label>

--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -8033,3 +8033,51 @@ odern Recommendations UX Styles */
 .modern-poi-card:nth-child(3n) {
     animation-delay: 0.2s;
 }
+
+/* Filters open button */
+#openFiltersBtn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px;
+    background: var(--primary-color);
+    color: #fff;
+    border: none;
+    border-radius: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-bottom: 16px;
+}
+
+/* Hide filters content by default */
+#filtersContent {
+    display: none;
+    max-height: none;
+}
+
+#filtersContent.active {
+    display: block;
+}
+
+/* Mobile bottom sheet styles */
+@media (max-width: 768px) {
+    #filtersContent {
+        display: block;
+        position: fixed;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+        max-height: 80vh;
+        background: #fff;
+        overflow-y: auto;
+        border-top-left-radius: 16px;
+        border-top-right-radius: 16px;
+        box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.15);
+        transform: translateY(100%);
+        transition: transform 0.3s ease-in-out;
+    }
+
+    #filtersContent.active {
+        transform: translateY(0);
+    }
+}

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -10493,19 +10493,22 @@ function initializeEnhancedFilters() {
     console.log('🎛️ Initializing enhanced filter system...');
     
     // Filter toggle functionality
+    const openFiltersBtn = document.getElementById('openFiltersBtn');
     const filtersToggleBtn = document.getElementById('filtersToggleBtn');
     const filtersContent = document.getElementById('filtersContent');
-    
+
+    if (openFiltersBtn && filtersContent) {
+        openFiltersBtn.addEventListener('click', () => {
+            filtersContent.classList.add('active');
+            openFiltersBtn.style.display = 'none';
+        });
+    }
+
     if (filtersToggleBtn && filtersContent) {
         filtersToggleBtn.addEventListener('click', () => {
-            const isExpanded = filtersContent.classList.contains('expanded');
-            
-            if (isExpanded) {
-                filtersContent.classList.remove('expanded');
-                filtersToggleBtn.classList.remove('expanded');
-            } else {
-                filtersContent.classList.add('expanded');
-                filtersToggleBtn.classList.add('expanded');
+            filtersContent.classList.remove('active');
+            if (openFiltersBtn) {
+                openFiltersBtn.style.display = '';
             }
         });
     }


### PR DESCRIPTION
## Summary
- hide filters panel by default and add a new 'Filtreleri Aç' button
- toggle filters panel with JavaScript for bottom-sheet behavior on mobile
- style filters panel for full-width mobile bottom sheet with slide animation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a2341d2304832098a92c86b9fb1508