### PR TITLE
Improve predefined route search focus and accessibility

### DIFF
--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -944,6 +944,13 @@
             bottom: 0;
             background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
             opacity: 0.3;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .predefined-routes-header .route-search {
+            position: relative;
+            z-index: 1;
         }
 
         .section-header-content {

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -4941,7 +4941,12 @@ async function switchTab(tabName) {
     } else if (tabName === 'predefined-routes') {
         predefinedTab.classList.add('active');
         predefinedContent.classList.add('active');
-        
+
+        const searchInput = document.getElementById('routeSearchInput');
+        if (searchInput) {
+            searchInput.focus();
+        }
+
         // Load predefined routes if not already loaded
         if (predefinedRoutes.length === 0) {
             await loadPredefinedRoutes();
@@ -6211,14 +6216,17 @@ function setupRouteSearch() {
     const searchInput = document.getElementById('routeSearchInput');
     if (!searchInput) return;
 
-    searchInput.addEventListener('input', () => {
+    const handleRouteSearch = () => {
         const query = searchInput.value.trim().toLowerCase();
         filteredRoutes = predefinedRoutes.filter(route =>
             route.name && route.name.toLowerCase().includes(query)
         );
         displayPredefinedRoutes(filteredRoutes);
         updateRouteStats();
-    });
+    };
+
+    // React to input events so the list updates as the user types
+    searchInput.addEventListener('input', handleRouteSearch);
 }
 
 function showNoRoutesMessage(message = 'Seçilen kriterlere uygun rota bulunamadı.') {


### PR DESCRIPTION
## Summary
- Focus predefined routes search field when switching tabs
- Handle route search through `input` events
- Prevent overlay from blocking search and raise search field above background

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `make quick` *(fails: Ruff check failed, 245 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a2399876f88320ae0346408966d2df