### PR TITLE
Handle broken route images with placeholders and adjust card styling

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -588,7 +588,7 @@
                             <template id="predefinedRouteCardTemplate">
                                 <div class="route-card">
                                     <div class="route-card-image">
-                                        <img src="" alt="">
+                                        <img src="" alt="" data-placeholder="https://via.placeholder.com/400x200?text=Rota">
                                     </div>
                                     <div class="route-card-content">
                                         <div class="route-card-header">

--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -1203,9 +1203,9 @@
         }
 
         .route-card {
-            background: #ffffff;
-            border: 1px solid #e2e8f0;
-            border-radius: 24px;
+            background: #f9fafb;
+            border: 1px solid #d1d5db;
+            border-radius: 16px;
             overflow: hidden;
             transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
             cursor: pointer;
@@ -6299,6 +6299,8 @@ ute Preview Map Styles */
     background-size: cover;
     background-position: center;
     overflow: hidden;
+    background-color: #e5e7eb;
+    border-bottom: 1px solid #d1d5db;
 }
 
 .route-card-image img {

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -6055,7 +6055,8 @@ function createRouteCard(route) {
     const difficultyStars = createDifficultyStars(difficultyLevel);
     const duration = Math.round((route.estimated_duration || 0) / 60);
     const stopCount = route.poi_count || (route.waypoints ? route.waypoints.length : 0);
-    const imageUrl = route.preview_image_url || route.image_url || 'https://via.placeholder.com/400x200?text=Rota';
+    const placeholderImage = 'https://via.placeholder.com/400x200?text=Rota';
+    const imageUrl = route.preview_image_url || route.image_url || placeholderImage;
     
     console.log('🏷️ Creating route card:', {
         name: route.name,
@@ -6066,7 +6067,7 @@ function createRouteCard(route) {
     return `
         <div class="route-card" data-route-id="${route.id}">
             <div class="route-card-image">
-                <img src="${imageUrl}" alt="${route.name || 'Rota görseli'}">
+                <img src="${imageUrl}" alt="${route.name || 'Rota görseli'}" data-placeholder="${placeholderImage}" onerror="handleImageError(event)">
             </div>
             <div class="route-card-header">
                 <h3 class="route-card-title">${route.name || 'İsimsiz Rota'}</h3>
@@ -6091,6 +6092,15 @@ function createRouteCard(route) {
             </div>
         </div>
     `;
+}
+
+function handleImageError(event) {
+    const img = event.target;
+    const placeholder = img.dataset.placeholder;
+    if (placeholder && img.src !== placeholder) {
+        img.onerror = null;
+        img.src = placeholder;
+    }
 }
 
 // Favori rota yönetimi


### PR DESCRIPTION
## Summary
- Add `data-placeholder` on route card template images
- Provide `handleImageError` helper and `onerror` fallback for route card images
- Tweak route card backgrounds and borders to reduce visual emptiness

## Testing
- `make quick` *(fails: Ruff check failed with numerous existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a23f78f440832084d99ae4326135e3