### PR TITLE
Calculate and display route distances in recommendation cards

### DIFF
--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -6326,6 +6326,22 @@ ute Preview Map Styles */
     color: #667eea;
 }
 
+.route-distance {
+    display: inline-flex;
+    align-items: center;
+    font-size: 14px;
+    font-weight: 500;
+    color: #374151;
+}
+
+.route-distance::before {
+    content: "\f4d7";
+    font-family: "Font Awesome 5 Free";
+    font-weight: 900;
+    margin-right: 4px;
+    color: #667eea;
+}
+
 /* Route selection highlighting on map */
 .route-on-map {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- ensure routes carry a distance value, computing from polyline geometry when missing
- show route length on cards via a new `route-distance` span element
- style route distance with readable typography and a Font Awesome route icon

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68a2418d8e388320bd021a86c54865bd