### PR TITLE
Add mini map to route recommendation cards

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -612,6 +612,7 @@
                                                 <div class="difficulty-stars"></div>
                                             </div>
                                         </div>
+                                        <div class="route-mini-map"></div>
                                     </div>
                                 </div>
                             </template>

--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -6342,6 +6342,16 @@ ute Preview Map Styles */
     color: #667eea;
 }
 
+/* Mini map container within route cards */
+.route-mini-map {
+    width: 100px;
+    height: 100px;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    margin-top: 8px;
+    overflow: hidden;
+}
+
 /* Route selection highlighting on map */
 .route-on-map {
     cursor: pointer;

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -6071,7 +6071,10 @@ function displayPredefinedRoutes(routes) {
             });
         }
     });
-    
+
+    // Render mini maps for each route
+    renderRouteMiniMaps(routes);
+
     // Update route statistics
     updateRouteStats();
 }
@@ -6120,8 +6123,51 @@ function createRouteCard(route) {
                     <div class="difficulty-stars">${difficultyStars}</div>
                 </div>
             </div>
+            <div class="route-mini-map" id="mini-map-${route.id}"></div>
         </div>
     `;
+}
+
+function renderRouteMiniMaps(routes) {
+    routes.forEach(route => {
+        const container = document.getElementById(`mini-map-${route.id}`);
+        if (!container) return;
+
+        let geometry = route.geometry;
+        if (!geometry) return;
+
+        // Parse geometry if provided as string
+        if (typeof geometry === 'string') {
+            try {
+                geometry = JSON.parse(geometry);
+            } catch {
+                return;
+            }
+        }
+
+        const coords = geometry.coordinates || (geometry.geometry && geometry.geometry.coordinates);
+        if (!coords || coords.length === 0) return;
+
+        const latlngs = coords.map(c => [c[1], c[0]]);
+
+        const map = L.map(container, {
+            attributionControl: false,
+            dragging: false,
+            zoomControl: false,
+            scrollWheelZoom: false,
+            doubleClickZoom: false,
+            boxZoom: false,
+            keyboard: false,
+            touchZoom: false
+        });
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18
+        }).addTo(map);
+
+        const line = L.polyline(latlngs, { interactive: false }).addTo(map);
+        map.fitBounds(line.getBounds());
+    });
 }
 
 function handleImageError(event) {


### PR DESCRIPTION
## Summary
- Show a mini map for each route recommendation using its geometry
- Style and position `.route-mini-map` containers within cards

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a242f3926483208ccfa9f8d2470d73