### PR TITLE
Add route media markers and preview images

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -588,7 +588,7 @@
                             <template id="predefinedRouteCardTemplate">
                                 <div class="route-card">
                                     <div class="route-card-image">
-                                        <img src="" alt="" data-placeholder="https://via.placeholder.com/400x200?text=Rota">
+                                        <img src="https://via.placeholder.com/400x200?text=Rota" alt="Rota önizlemesi" data-placeholder="https://via.placeholder.com/400x200?text=Rota">
                                     </div>
                                     <div class="route-card-content">
                                         <div class="route-card-header">

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -6086,7 +6086,7 @@ function createRouteCard(route) {
     const stopCount = route.poi_count || (route.waypoints ? route.waypoints.length : 0);
     const distance = ensureRouteDistance(route).toFixed(1);
     const placeholderImage = 'https://via.placeholder.com/400x200?text=Rota';
-    const imageUrl = route.preview_image_url || route.image_url || placeholderImage;
+    const imageUrl = route.preview_image || placeholderImage;
     
     console.log('🏷️ Creating route card:', {
         name: route.name,


### PR DESCRIPTION
## Summary
- Load route media on route detail modal and display Leaflet markers with image popups
- Show route preview images in recommendation cards with placeholder fallback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_68a253b4e3008320905bcb1bba3d715d