### PR TITLE
Add admin route media retrieval endpoint and tests

### DIFF
--- a/app/routes/route.py
+++ b/app/routes/route.py
@@ -277,6 +277,24 @@ def admin_get_route(route_id):
         raise APIError("Internal server error", "INTERNAL_ERROR", 500)
 
 
+@route_bp.route('/admin/routes/<int:route_id>/media', methods=['GET'])
+@auth_middleware.require_auth
+def admin_list_route_media(route_id):
+    """Admin: Get media files for a route."""
+    try:
+        if not route_id:
+            raise bad_request("Route ID is required")
+
+        media = route_service.list_route_media(route_id)
+        return jsonify({'route_id': route_id, 'media': media}), 200
+
+    except APIError:
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in admin_list_route_media: {e}")
+        raise APIError("Internal server error", "INTERNAL_ERROR", 500)
+
+
 @route_bp.route('/admin/routes/<int:route_id>/media', methods=['POST'])
 @auth_middleware.require_auth
 def admin_add_route_media(route_id):


### PR DESCRIPTION
## Summary
- Add authenticated admin GET endpoint to retrieve route media
- Register admin route media test and environment setup for authentication
- Cover new endpoint with unit tests

## Testing
- `pytest test_api_endpoints.py::TestAdminRouteAPIEndpoints::test_admin_get_route_media_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c9fd1e448320b6f73329352ac37a