### PR TITLE
Handle missing route media gracefully

### DIFF
--- a/static/js/route-admin-manager.js
+++ b/static/js/route-admin-manager.js
@@ -384,31 +384,21 @@ class RouteAdminManager {
      * Load existing media for a route
      */
     async loadRouteMedia(routeId) {
-        const endpoints = [
-            `${this.apiBase}/admin/routes/${routeId}/media`,
-            `${this.apiBase}/routes/${routeId}/media`
-        ];
-
-        for (const url of endpoints) {
-            try {
-                const data = await this.apiClient.get(url);
-                const mediaList = data.media || data || [];
-                this.routeMedia = Array.isArray(mediaList) ? mediaList : [];
-                this.mediaMarkers.forEach(m => this.map && this.map.removeLayer(m.marker));
-                this.mediaMarkers = [];
-                this.routeMedia.forEach(m => this.addMediaMarker(m));
-                this.renderMediaList();
-                return;
-            } catch (err) {
-                if (err.status !== 404) {
-                    console.error('Media load error:', err);
-                    return;
-                }
+        const url = `${this.apiBase}/routes/${routeId}/media`;
+        try {
+            const data = await this.apiClient.get(url);
+            const mediaList = data.media || data || [];
+            this.routeMedia = Array.isArray(mediaList) ? mediaList : [];
+        } catch (err) {
+            if (err.status !== 404) {
+                console.error('Media load error:', err);
             }
-
+            this.routeMedia = [];
         }
 
-        this.routeMedia = [];
+        this.mediaMarkers.forEach(m => this.map && this.map.removeLayer(m.marker));
+        this.mediaMarkers = [];
+        this.routeMedia.forEach(m => this.addMediaMarker(m));
         this.renderMediaList();
     }
 


### PR DESCRIPTION
## Summary
- Simplify route media loading to use only the public `/api/routes/{id}/media` endpoint
- Treat 404 responses as an empty media list and clear existing markers when no media is returned

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- Manual: executed `loadRouteMedia` with a simulated 404 response; media list rendered empty without console errors

------
https://chatgpt.com/codex/tasks/task_e_68a2cbc9004c832097def96b5d60cb96