### PR TITLE
Enhance route media upload UX with map-guided coordinates

### DIFF
--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -622,6 +622,77 @@
         #routeMap {
             flex: 1;
             min-height: 400px;
+            position: relative;
+        }
+
+        #routeMap.select-location {
+            cursor: crosshair;
+        }
+
+        #routeMap.select-location::after {
+            content: 'Fotoğraf konumu için haritaya tıklayın';
+            position: absolute;
+            top: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(0, 0, 0, 0.7);
+            color: #fff;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            pointer-events: none;
+            z-index: 1000;
+        }
+
+        .route-media-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+            gap: 1rem;
+        }
+
+        .route-media-card {
+            background: white;
+            border: 2px solid var(--route-border);
+            border-radius: var(--route-radius);
+            overflow: hidden;
+            position: relative;
+            transition: var(--route-transition);
+        }
+
+        .route-media-card:hover {
+            border-color: var(--route-primary);
+            box-shadow: var(--route-shadow-hover);
+            transform: translateY(-2px);
+        }
+
+        .route-media-thumb {
+            width: 100%;
+            height: 100px;
+            object-fit: cover;
+        }
+
+        .route-media-delete {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            background: rgba(0, 0, 0, 0.6);
+            color: #fff;
+            border-radius: 50%;
+            width: 24px;
+            height: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+        }
+
+        .route-media-panel {
+            background: white;
+            border-radius: var(--route-radius);
+            border: 2px solid var(--route-border);
+            padding: 1rem;
+            max-height: 100%;
+            overflow-y: auto;
         }
 
         /* Elevation Chart Container */
@@ -1192,6 +1263,37 @@
                 <div id="routeElevationChartContainer" class="elevation-chart-hidden"></div>
             </div>
         </section>
+    </div>
+
+    <!-- Route Media Modal -->
+    <div class="modal fade" id="routeMediaModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Fotoğraf Ekle</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="routeMediaFile" class="form-label">Fotoğraf Seç</label>
+                        <input type="file" id="routeMediaFile" class="form-control" accept="image/*">
+                    </div>
+                    <div class="mb-3">
+                        <label for="routeMediaCaption" class="form-label">Açıklama</label>
+                        <input type="text" id="routeMediaCaption" class="form-control" placeholder="Fotoğraf açıklaması">
+                    </div>
+                    <div class="form-check mb-3">
+                        <input type="checkbox" id="routeMediaPrimary" class="form-check-input">
+                        <label for="routeMediaPrimary" class="form-check-label">Ana fotoğraf olarak ayarla</label>
+                    </div>
+                    <p class="text-muted small mb-0">Yükleme sonrası fotoğraf konumunu haritadan seçmeniz istenecek.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">İptal</button>
+                    <button type="button" class="btn btn-primary" id="routeMediaStartBtn">Yüklemeye Başla</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Scripts -->
@@ -3528,9 +3630,10 @@
                         </div>
                     </form>
                     <div class="route-media-panel flex-grow-1">
-                        <button type="button" id="addRouteImageBtn" class="btn btn-secondary mb-2">Fotoğraf Ekle</button>
-                        <input type="file" id="routeImageInput" accept="image/*" style="display:none">
-                        <ul id="routeMediaList" class="list-group"></ul>
+                        <button type="button" id="addRouteImageBtn" class="btn btn-secondary mb-3">
+                            <i class="fas fa-plus me-1"></i>Fotoğraf Ekle
+                        </button>
+                        <div id="routeMediaList" class="route-media-grid"></div>
                     </div>
                 </div>
             `;

--- a/static/js/route-admin-manager.js
+++ b/static/js/route-admin-manager.js
@@ -15,11 +15,12 @@ class RouteAdminManager {
         this.isDirty = false; // Track unsaved changes
 
         // Route media management
-        this.pendingMediaFile = null;
+        this.pendingMediaData = null; // {file, caption, isPrimary}
         this.routeMedia = [];
         this.mediaMarkers = [];
         this.handleMapClickBound = null;
         this.map = null;
+        this.escHandler = null;
         
         // API client setup
         // Use explicit API base path to avoid relative URL issues when the admin
@@ -339,26 +340,75 @@ class RouteAdminManager {
      */
     setupMediaHandlers() {
         const addBtn = this.container.querySelector('#addRouteImageBtn');
-        const fileInput = this.container.querySelector('#routeImageInput');
-        if (addBtn && fileInput) {
-            addBtn.addEventListener('click', () => fileInput.click());
-            fileInput.addEventListener('change', (e) => {
-                this.pendingMediaFile = e.target.files[0];
-                if (this.pendingMediaFile) {
-                    this.showNotification('Fotoğraf konumu için haritadan bir nokta seçin', 'info');
+        const modalEl = document.getElementById('routeMediaModal');
+        const fileInput = document.getElementById('routeMediaFile');
+        const captionInput = document.getElementById('routeMediaCaption');
+        const primaryInput = document.getElementById('routeMediaPrimary');
+        const startBtn = document.getElementById('routeMediaStartBtn');
+
+        if (addBtn && modalEl && fileInput && startBtn) {
+            const modal = new bootstrap.Modal(modalEl);
+            addBtn.addEventListener('click', () => {
+                fileInput.value = '';
+                captionInput.value = '';
+                primaryInput.checked = false;
+                modal.show();
+            });
+
+            startBtn.addEventListener('click', () => {
+                if (!fileInput.files.length) {
+                    this.showNotification('Lütfen bir fotoğraf seçin', 'error');
+                    return;
                 }
+                this.pendingMediaData = {
+                    file: fileInput.files[0],
+                    caption: captionInput.value,
+                    isPrimary: primaryInput.checked
+                };
+                modal.hide();
+                this.showNotification('Fotoğraf konumu için haritadan bir nokta seçin. İptal için ESC', 'info');
+                this.startCoordinateSelection();
             });
         }
+    }
+
+    startCoordinateSelection() {
+        if (!this.map) return;
+        const mapContainer = this.map.getContainer();
+        mapContainer.classList.add('select-location');
+        this.escHandler = (e) => {
+            if (e.key === 'Escape') {
+                this.cancelCoordinateSelection();
+                this.showNotification('Fotoğraf konumu seçimi iptal edildi', 'warning');
+            }
+        };
+        document.addEventListener('keydown', this.escHandler);
+    }
+
+    cancelCoordinateSelection() {
+        if (this.map) {
+            this.map.getContainer().classList.remove('select-location');
+        }
+        if (this.escHandler) {
+            document.removeEventListener('keydown', this.escHandler);
+            this.escHandler = null;
+        }
+        this.pendingMediaData = null;
+        const fileInput = document.getElementById('routeMediaFile');
+        if (fileInput) fileInput.value = '';
     }
 
     /**
      * Handle map click for media placement
      */
     async handleMapClick(e) {
-        if (!this.pendingMediaFile || !this.currentRoute) return;
+        if (!this.pendingMediaData || !this.currentRoute) return;
+        const { file, caption, isPrimary } = this.pendingMediaData;
         const routeId = this.currentRoute.id;
         const formData = new FormData();
-        formData.append('file', this.pendingMediaFile);
+        formData.append('file', file);
+        formData.append('caption', caption);
+        formData.append('is_primary', isPrimary);
         formData.append('lat', e.latlng.lat);
         formData.append('lng', e.latlng.lng);
         try {
@@ -374,9 +424,7 @@ class RouteAdminManager {
             console.error('Media upload error:', err);
             this.showNotification('Medya yüklenemedi', 'error');
         } finally {
-            this.pendingMediaFile = null;
-            const fileInput = this.container.querySelector('#routeImageInput');
-            if (fileInput) fileInput.value = '';
+            this.cancelCoordinateSelection();
         }
     }
 
@@ -423,18 +471,26 @@ class RouteAdminManager {
      * Render media list panel
      */
     renderMediaList() {
-        const listEl = this.container.querySelector('#routeMediaList');
-        if (!listEl) return;
-        listEl.innerHTML = '';
+        const container = this.container.querySelector('#routeMediaList');
+        if (!container) return;
+        container.innerHTML = '';
+        if (this.routeMedia.length === 0) {
+            container.innerHTML = '<div class="text-muted">Henüz fotoğraf eklenmemiş.</div>';
+            return;
+        }
         this.routeMedia.forEach(media => {
-            const li = document.createElement('li');
-            li.className = 'list-group-item d-flex justify-content-between align-items-center';
-            const name = media.filename || media.file_path?.split('/').pop() || media.id;
-            li.innerHTML = `<span>${name}</span>` +
-                `<i class="fas fa-trash text-danger delete-media" data-id="${media.id}"></i>`;
-            listEl.appendChild(li);
+            const item = document.createElement('div');
+            item.className = 'route-media-card';
+            const imageUrl = media.thumbnail_path ? `/${media.thumbnail_path}` : (media.url || '');
+            const name = media.caption || media.filename || media.id;
+            item.innerHTML = `
+                ${imageUrl ? `<img src="${imageUrl}" class="route-media-thumb" alt="${name}">` : ''}
+                <div class="p-2 small text-truncate">${name}</div>
+                <div class="route-media-delete" data-id="${media.id}"><i class="fas fa-trash"></i></div>
+            `;
+            container.appendChild(item);
         });
-        listEl.querySelectorAll('.delete-media').forEach(el => {
+        container.querySelectorAll('.route-media-delete').forEach(el => {
             el.addEventListener('click', () => this.deleteMedia(el.dataset.id));
         });
     }


### PR DESCRIPTION
## Summary
- Add Bootstrap modal for route photo uploads with caption and primary selection
- Implement map crosshair mode to pick photo coordinates with ESC cancel
- Display existing route media as a thumbnail grid with delete controls

## Testing
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a3823b2e6083209448cfbe5096b88f