### PR TITLE
Fix route media upload field name mismatch

### DIFF
--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -3439,7 +3439,10 @@
             }
 
             const formData = new FormData();
-            formData.append('media', file);
+            // Backend API expects the uploaded file under the 'file' field name
+            // Using a different key results in the server thinking no file was provided
+            // and returning a 404/HTML error page which then breaks JSON parsing
+            formData.append('file', file);
             formData.append('caption', mediaCaption);
             formData.append('is_primary', isPrimary);
 

--- a/test_route_media_endpoints.py
+++ b/test_route_media_endpoints.py
@@ -32,8 +32,11 @@ def test_route_media_endpoints():
     if test_image_path:
         try:
             # Upload test
+            # The backend expects the uploaded file under the 'file' key.
+            # Using a different key causes the server to return a 404/HTML response
+            # which then fails JSON parsing on the client.
             files = {
-                'media': ('test_image.jpg', open(test_image_path, 'rb'), 'image/jpeg')
+                'file': ('test_image.jpg', open(test_image_path, 'rb'), 'image/jpeg')
             }
             
             data = {


### PR DESCRIPTION
## Summary
- Align client upload field name with backend expectation
- Document expected field name in tests for route media upload

## Testing
- `pytest test_route_media_endpoints.py::test_route_media_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_68a399b38c4c83209a4f90d85f9796c4