### PR TITLE
Fix POI marker drift on predefined routes map

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5259,9 +5259,10 @@ async function displayRouteOnMap(route) {
                                         border-radius: 50%; 
                                         display: flex; 
                                         align-items: center; 
-                                        justify-content: center; 
+                                        justify-content: center;
                                         font-weight: bold;
                                         border: 3px solid white;
+                                        box-sizing: border-box;
                                         box-shadow: 0 3px 8px rgba(0,0,0,0.4);
                                         font-size: 16px;
                                         position: relative;
@@ -5285,7 +5286,7 @@ async function displayRouteOnMap(route) {
                                         ">${index + 1}</span>
                                     </div>`,
                                     iconSize: [35, 35],
-                                    iconAnchor: [17, 17]
+                                    iconAnchor: [17.5, 17.5]
                                 })
                             }).addTo(predefinedMap);
 


### PR DESCRIPTION
## Summary
- keep POI marker border inside the icon size to avoid zoom-dependent offset
- center predefined-route POI markers by using fractional icon anchors

## Testing
- `pytest` *(fails: 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a575abceb4832080068b481105b447