### PR TITLE
Extract route media location from EXIF

### DIFF
--- a/poi_api.py
+++ b/poi_api.py
@@ -4123,21 +4123,6 @@ def upload_route_media(route_id: int):
         # Get form data
         caption = request.form.get('caption', '')
         is_primary = request.form.get('is_primary', 'false').lower() == 'true'
-        lat = request.form.get('lat')
-        lng = request.form.get('lng')
-        
-        # Convert coordinates if provided
-        latitude = None
-        longitude = None
-        if lat and lng:
-            try:
-                latitude = float(lat)
-                longitude = float(lng)
-            except ValueError:
-                return jsonify({
-                    'success': False,
-                    'error': 'Invalid coordinates provided'
-                }), 400
         
         # Save file temporarily
         temp_dir = tempfile.mkdtemp()
@@ -4154,9 +4139,7 @@ def upload_route_media(route_id: int):
                 route_name=route_name,
                 media_file_path=temp_file_path,
                 caption=caption,
-                is_primary=is_primary,
-                lat=latitude,
-                lng=longitude
+                is_primary=is_primary
             )
             
             if not media_info:
@@ -4171,8 +4154,10 @@ def upload_route_media(route_id: int):
                 cur = conn.cursor(cursor_factory=RealDictCursor)
                 
                 # Insert into route_media table
+                db_lat = media_info.get('lat')
+                db_lng = media_info.get('lng')
                 cur.execute("""
-                    INSERT INTO route_media (route_id, file_path, thumbnail_path, 
+                    INSERT INTO route_media (route_id, file_path, thumbnail_path,
                                            lat, lng, caption, is_primary, media_type, uploaded_at)
                     VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                     RETURNING id
@@ -4180,8 +4165,8 @@ def upload_route_media(route_id: int):
                     route_id,
                     media_info['file_path'],
                     media_info['thumbnail_path'],
-                    latitude,
-                    longitude,
+                    db_lat,
+                    db_lng,
                     caption,
                     is_primary,
                     media_info['media_type'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ networkx==3.5
 numpy==2.3.2
 osmnx==2.0.5
 Pillow==11.3.0
+piexif==1.1.3
 psycopg2==2.9.10
 python-dotenv==1.1.1
 python-bcrypt==0.3.2

--- a/test_exif_location_extraction.py
+++ b/test_exif_location_extraction.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+from poi_media_manager import POIMediaManager
+from PIL import Image
+import piexif
+
+
+def _create_image_with_exif(path: str, lat: float, lng: float):
+    img = Image.new('RGB', (10, 10), color='red')
+
+    def _to_deg(value):
+        d = int(value)
+        m = int((value - d) * 60)
+        s = (value - d - m/60) * 3600
+        return (
+            (d, 1),
+            (m, 1),
+            (int(s * 1000000), 1000000)
+        )
+
+    lat_ref = 'N' if lat >= 0 else 'S'
+    lng_ref = 'E' if lng >= 0 else 'W'
+    lat = abs(lat)
+    lng = abs(lng)
+
+    exif_dict = {
+        'GPS': {
+            piexif.GPSIFD.GPSLatitudeRef: lat_ref,
+            piexif.GPSIFD.GPSLatitude: _to_deg(lat),
+            piexif.GPSIFD.GPSLongitudeRef: lng_ref,
+            piexif.GPSIFD.GPSLongitude: _to_deg(lng),
+        }
+    }
+    exif_bytes = piexif.dump(exif_dict)
+    img.save(path, "jpeg", exif=exif_bytes)
+
+
+def test_extract_gps_from_exif():
+    manager = POIMediaManager()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        img_path = os.path.join(tmpdir, "exif.jpg")
+        lat, lng = 40.1234, 29.9876
+        _create_image_with_exif(img_path, lat, lng)
+
+        info = manager.add_route_media(
+            route_id=1,
+            route_name="TestRoute",
+            media_file_path=img_path
+        )
+        assert info is not None
+        assert info['lat'] is not None and info['lng'] is not None
+        assert abs(info['lat'] - lat) < 0.01
+        assert abs(info['lng'] - lng) < 0.01
+
+        # cleanup
+        manager.delete_route_media(1, info['filename'])


### PR DESCRIPTION
## Summary
- derive route media coordinates from image EXIF GPS data
- drop form lat/lng and persist EXIF coordinates when available
- add regression test for EXIF location parsing

## Testing
- `pytest test_exif_location_extraction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b3d176bc832093347c5cc6cf846f