### PR TITLE
feat: show media on elevation charts

### DIFF
--- a/assets/js/elevation-media-markers.js
+++ b/assets/js/elevation-media-markers.js
@@ -1,0 +1,174 @@
+export function initElevationMediaMarkers({
+  map,
+  elevationControl,
+  trackCoords = [],
+  mediaList = [],
+  createOrGetMarker
+}) {
+  if (!elevationControl || !Array.isArray(trackCoords) || trackCoords.length === 0) {
+    console.warn('initElevationMediaMarkers: Missing elevation data');
+    return;
+  }
+  if (!Array.isArray(mediaList) || mediaList.length === 0) {
+    return;
+  }
+
+  // Helper: haversine distance in km
+  function haversine(lat1, lon1, lat2, lon2) {
+    const R = 6371e3; // metres
+    const toRad = x => x * Math.PI / 180;
+    const φ1 = toRad(lat1);
+    const φ2 = toRad(lat2);
+    const Δφ = toRad(lat2 - lat1);
+    const Δλ = toRad(lon2 - lon1);
+    const a = Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+              Math.cos(φ1) * Math.cos(φ2) *
+              Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return (R * c) / 1000; // return in km
+  }
+
+  // Pre-compute cumulative distances
+  const cumDistances = [0];
+  for (let i = 1; i < trackCoords.length; i++) {
+    const prev = trackCoords[i - 1];
+    const curr = trackCoords[i];
+    const d = haversine(prev.lat, prev.lng, curr.lat, curr.lng);
+    cumDistances[i] = cumDistances[i - 1] + d;
+  }
+
+  function nearestPoint(lat, lng) {
+    let best = 0;
+    let min = Infinity;
+    for (let i = 0; i < trackCoords.length; i++) {
+      const p = trackCoords[i];
+      const dist = haversine(lat, lng, p.lat, p.lng);
+      if (dist < min) {
+        min = dist;
+        best = i;
+      }
+    }
+    return {
+      index: best,
+      distance: cumDistances[best],
+      elevation: trackCoords[best].elev || trackCoords[best].elevation || 0
+    };
+  }
+
+  // Access underlying d3 chart
+  const container = elevationControl._container || elevationControl.container || null;
+  if (!container) return;
+  const svgNode = container.querySelector('svg');
+  if (!svgNode) return;
+  const svg = d3.select(svgNode);
+
+  // Remove existing markers
+  svg.select('g.elevation-media-markers').remove();
+  const layer = svg.append('g').attr('class', 'elevation-media-markers');
+
+  const chart = elevationControl._chart || elevationControl.chart || {};
+  const xScale = chart.x || (d => d);
+  const yScale = chart.y || (d => d);
+
+  const iconMap = new Map();
+
+  // To avoid overlap on same x
+  const xUsage = {};
+
+  mediaList.forEach(media => {
+    const lat = parseFloat(media.lat ?? media.latitude);
+    const lng = parseFloat(media.lng ?? media.longitude ?? media.lon);
+    if (!isFinite(lat) || !isFinite(lng)) {
+      console.warn('Media without coordinates', media);
+      return;
+    }
+    const info = nearestPoint(lat, lng);
+    const x = xScale(info.distance);
+    let y = yScale(info.elevation);
+    const key = Math.round(x);
+    const offset = (xUsage[key] || 0) * 8;
+    xUsage[key] = (xUsage[key] || 0) + 1;
+    y -= offset;
+
+    const g = layer.append('g')
+      .attr('class', 'elevation-media-marker')
+      .attr('transform', `translate(${x},${y})`);
+
+    g.append('text')
+      .attr('class', 'camera-icon')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'central')
+      .attr('font-size', 16)
+      .text('\uD83D\uDCF7');
+
+    if (media.id) {
+      iconMap.set(media.id, g);
+    }
+
+    // Interaction with map markers
+    const getMarker = () => createOrGetMarker ? createOrGetMarker(media) : null;
+
+    const showThumbnail = () => {
+      const marker = getMarker();
+      if (marker) {
+        marker.openPopup();
+      }
+      if (media.thumbnailUrl) {
+        const popup = L.popup({ autoPan: false, closeButton: false, className: 'elevation-media-popup' })
+          .setLatLng(marker ? marker.getLatLng() : [lat, lng])
+          .setContent(`<img src="${media.thumbnailUrl}" style="max-width:120px;max-height:80px;"/>`)
+          .openOn(map);
+        g.on('mouseout', () => map.closePopup(popup));
+      }
+    };
+
+    g.on('mouseenter', () => {
+      g.classed('active', true);
+      showThumbnail();
+    });
+    g.on('mouseleave', () => {
+      g.classed('active', false);
+    });
+    g.on('click', () => {
+      const marker = getMarker();
+      if (marker) marker.openPopup();
+    });
+
+    const marker = getMarker();
+    if (marker) {
+      marker.on('mouseover', () => g.classed('active', true));
+      marker.on('mouseout', () => g.classed('active', false));
+    }
+  });
+
+  function reposition() {
+    const xScale = chart.x || (d => d);
+    const yScale = chart.y || (d => d);
+    const usage = {};
+    mediaList.forEach(media => {
+      const icon = media.id ? iconMap.get(media.id) : null;
+      if (!icon) return;
+      const lat = parseFloat(media.lat ?? media.latitude);
+      const lng = parseFloat(media.lng ?? media.longitude ?? media.lon);
+      const info = nearestPoint(lat, lng);
+      const x = xScale(info.distance);
+      let y = yScale(info.elevation);
+      const key = Math.round(x);
+      const off = (usage[key] || 0) * 8;
+      usage[key] = (usage[key] || 0) + 1;
+      y -= off;
+      icon.attr('transform', `translate(${x},${y})`);
+    });
+  }
+
+  // listen to chart resize/redraw
+  if (elevationControl.on) {
+    elevationControl.on('elechart_resize', reposition);
+    elevationControl.on('elechart_redraw', reposition);
+  }
+  window.addEventListener('resize', reposition);
+}
+
+if (typeof window !== 'undefined') {
+  window.initElevationMediaMarkers = initElevationMediaMarkers;
+}

--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -934,6 +934,7 @@
     <script src="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.js"></script>
     <script src="static/js/rate-limiter.js"></script>
     <script src="static/js/elevation-chart.js"></script>
+    <script src="assets/js/elevation-media-markers.js"></script>
     <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/poi_recommendation_system.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet-routing-machine@3.2.12/dist/leaflet-routing-machine.css" />

--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -1492,6 +1492,7 @@
     <script src="static/js/map-layer-control.js"></script>
     <script src="static/js/rate-limiter.js"></script>
     <script src="static/js/elevation-chart.js"></script>
+    <script src="assets/js/elevation-media-markers.js"></script>
     <script src="static/js/api-client.js"></script>
     <script src="static/js/navigation-manager.js"></script>
     <script src="static/js/route-admin-manager.js"></script>
@@ -1820,13 +1821,22 @@
                                     });
 
                                                         // Pass to elevation chart so markers appear on profile
-                    if (window.routeElevationChart) {
-                        window.routeElevationChart.setMediaMarkers(locatedMedia);
+                    if (window.initElevationMediaMarkers && window.routeElevationChart && window.routeElevationChart.elevationData) {
+                        initElevationMediaMarkers({
+                            map,
+                            elevationControl: window.routeElevationChart,
+                            trackCoords: window.routeElevationChart.elevationData,
+                            mediaList: locatedMedia,
+                            createOrGetMarker: media => photoLocationMarkers[media.filename] || photoLocationMarkers[media.id]
+                        });
                     }
                     
                     // Store located media for elevation chart updates
                     if (window.routeElevationChart && locatedMedia.length > 0) {
-                        window.routeElevationChart.setPhotoLocations(locatedMedia);
+                        // Legacy compatibility retained if needed
+                        if (window.routeElevationChart.setPhotoLocations) {
+                            window.routeElevationChart.setPhotoLocations(locatedMedia);
+                        }
                     }
                                 }
                             } catch (e) {
@@ -4628,11 +4638,23 @@
                                 .addTo(map);
                             poiMarkersLayer.addLayer(mk);
                         });
-                        if (window.routeElevationChart) {
-                            window.routeElevationChart.setMediaMarkers(located);
+                        if (window.initElevationMediaMarkers && window.routeElevationChart && window.routeElevationChart.elevationData) {
+                            initElevationMediaMarkers({
+                                map,
+                                elevationControl: window.routeElevationChart,
+                                trackCoords: window.routeElevationChart.elevationData,
+                                mediaList: located,
+                                createOrGetMarker: media => photoLocationMarkers[media.id] || photoLocationMarkers[media.filename]
+                            });
                         }
-                    } else if (window.routeElevationChart) {
-                        window.routeElevationChart.setMediaMarkers([]);
+                    } else if (window.initElevationMediaMarkers && window.routeElevationChart) {
+                        initElevationMediaMarkers({
+                            map,
+                            elevationControl: window.routeElevationChart,
+                            trackCoords: window.routeElevationChart.elevationData || [],
+                            mediaList: [],
+                            createOrGetMarker: () => null
+                        });
                     }
                 } catch (e) {
                     console.warn('Medya konumları haritaya eklenemedi:', e);
@@ -5376,8 +5398,14 @@
                     });
 
                     // Update elevation chart
-                    if (window.routeElevationChart) {
-                        window.routeElevationChart.setMediaMarkers(locatedMedia);
+                    if (window.initElevationMediaMarkers && window.routeElevationChart && window.routeElevationChart.elevationData) {
+                        initElevationMediaMarkers({
+                            map,
+                            elevationControl: window.routeElevationChart,
+                            trackCoords: window.routeElevationChart.elevationData,
+                            mediaList: locatedMedia,
+                            createOrGetMarker: media => photoLocationMarkers[media.filename] || photoLocationMarkers[media.id]
+                        });
                     }
                 }
             } catch (error) {
@@ -5772,24 +5800,28 @@
 
         // Enhanced elevation chart integration for photo locations
         function enhanceElevationChartWithPhotoLocations() {
-            if (!window.routeElevationChart) return;
-            
-            // Add photo location markers to elevation chart
-            const locatedMedia = Object.values(photoLocationMarkers).map(marker => {
+            if (!window.routeElevationChart || !window.initElevationMediaMarkers) return;
+
+            // Collect photo locations from map markers
+            const mediaList = Object.entries(photoLocationMarkers).map(([id, marker]) => {
                 const latlng = marker.getLatLng();
-                const filename = marker.options.filename || 'Unknown';
                 return {
-                    filename: filename,
-                    latitude: latlng.lat,
-                    longitude: latlng.lng,
+                    id,
                     lat: latlng.lat,
-                    lng: latlng.lng
+                    lng: latlng.lng,
+                    thumbnailUrl: marker.options?.thumbnailUrl
                 };
             });
-            
-            if (locatedMedia.length > 0) {
-                window.routeElevationChart.setMediaMarkers(locatedMedia);
-                console.log('Photo locations added to elevation chart:', locatedMedia.length);
+
+            if (mediaList.length > 0 && window.routeElevationChart.elevationData) {
+                initElevationMediaMarkers({
+                    map,
+                    elevationControl: window.routeElevationChart,
+                    trackCoords: window.routeElevationChart.elevationData,
+                    mediaList,
+                    createOrGetMarker: media => photoLocationMarkers[media.id]
+                });
+                console.log('Photo locations added to elevation chart:', mediaList.length);
             }
         }
 


### PR DESCRIPTION
## Summary
- add reusable `initElevationMediaMarkers` module to render media icons on elevation profiles
- integrate media markers into route manager and recommendation system elevation charts
- map media markers to thumbnails and associated Leaflet markers

## Testing
- `python -m pytest -q` *(fails: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68a6c956ed048320a365cc3c7b236c03