### PR TITLE
chore: remove legacy refresh media markers button

### DIFF
--- a/poi_recommendation_system.html
+++ b/poi_recommendation_system.html
@@ -445,10 +445,6 @@
                                 <i class="fas fa-toggle-on"></i>
                                 <span>Özel İçerik</span>
                             </button>
-                            <button type="button" class="btn btn-outline-success btn-sm" title="Mevcut rotanın medya işaretlerini yenile" id="refreshMediaBtn">
-                                <i class="fas fa-camera"></i>
-                                <span>Medya İşaretlerini Yenile</span>
-                            </button>
                         </div>
 
                         <!-- Quick Stats -->

--- a/static/css/poi_recommendation_system.css
+++ b/static/css/poi_recommendation_system.css
@@ -8403,8 +8403,4 @@ odern Recommendations UX Styles */
     z-index: 10;
 }
 
-#refreshMediaBtn {
-    display: none;
-}
-
 }

--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -3947,9 +3947,6 @@ async function refreshMediaMarkers(routeId = window.currentRouteId) {
 
 window.refreshMediaMarkers = refreshMediaMarkers;
 
-document.getElementById('refreshMediaBtn')?.addEventListener('click', () => {
-    refreshMediaMarkers();
-});
 
 // Export predefined route to Google Earth (for hiking trails)
 function exportPredefinedRouteToGoogleEarth(routeId) {
@@ -5459,12 +5456,6 @@ async function displayRouteOnMap(route) {
                     
                     console.log('✅ Route with POIs displayed on predefined map');
                     
-                    // Show refresh media button
-                    const refreshMediaBtn = document.getElementById('refreshMediaBtn');
-                    if (refreshMediaBtn) {
-                        refreshMediaBtn.style.display = 'inline-flex';
-                    }
-                    
                     // Create elevation chart for predefined route with geometry
                     if (window.ElevationChart && coords && coords.length > 1) {
                         if (predefinedElevationChart) {
@@ -5602,12 +5593,6 @@ async function displayRouteOnMap(route) {
                 
                 console.log('✅ Route POIs displayed on predefined map');
                 
-                // Show refresh media button
-                const refreshMediaBtn = document.getElementById('refreshMediaBtn');
-                if (refreshMediaBtn) {
-                    refreshMediaBtn.style.display = 'inline-flex';
-                }
-                
                 // Create elevation chart for predefined route
                 if (window.ElevationChart && validPois.length > 1) {
                     if (predefinedElevationChart) {
@@ -5675,11 +5660,6 @@ function clearPredefinedMapContent() {
         console.log('✅ Predefined map content cleared');
     }
     
-    // Hide refresh media button when no route is displayed
-    const refreshMediaBtn = document.getElementById('refreshMediaBtn');
-    if (refreshMediaBtn) {
-        refreshMediaBtn.style.display = 'none';
-    }
 }
 
 // Create enhanced media marker icon based on media type

--- a/user_ready_routes.html
+++ b/user_ready_routes.html
@@ -104,10 +104,6 @@
                                 <i class="fas fa-toggle-on"></i>
                                 <span>Özel İçerik</span>
                             </button>
-                            <button type="button" class="btn btn-outline-success btn-sm" title="Mevcut rotanın medya işaretlerini yenile" id="refreshMediaBtn">
-                                <i class="fas fa-camera"></i>
-                                <span>Medya İşaretlerini Yenile</span>
-                            </button>
                         </div>
 
                         <!-- Quick Stats -->


### PR DESCRIPTION
## Summary
- remove unused refresh media markers button from route recommendation pages
- drop related JavaScript event listener and styling

## Testing
- `pytest` *(fails: SystemExit: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a7091742c48320acdaaf9eec3c3ad8