### PR TITLE
refactor: unify manual and exif location flows

### DIFF
--- a/route_manager_enhanced.html
+++ b/route_manager_enhanced.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
         integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/exif-js"></script>
     <style>
         :root {
             --route-primary: #2563eb;
@@ -1900,6 +1901,19 @@
             'seyir_noktalari': { name: '📷 Seyir Noktaları', icon: 'camera', color: '#ff9500' }
         };
 
+        // YENİ: ortak tek giriş noktası
+        function setLocationFromLatLon(lat, lon, options = {}) {
+            if (!window.photoMarker) window.photoMarker = L.marker([lat, lon], { draggable: true }).addTo(map);
+            else window.photoMarker.setLatLng([lat, lon]);
+
+            try { map.setView([lat, lon], options.zoom ?? 16); } catch (e) {}
+
+            (document.getElementById('lat') || document.querySelector('[name="lat"]'))?.setAttribute('value', lat);
+            (document.getElementById('lon') || document.getElementById('lng') || document.querySelector('[name="lon"],[name="lng"]'))?.setAttribute('value', lon);
+        }
+
+        function dmsToDec(arr, ref) { if (!arr) return null; const [d, m, s] = arr; let v = d + m / 60 + s / 3600; return (ref === 'S' || ref === 'W') ? -v : v; }
+
         // Initialize application
         document.addEventListener('DOMContentLoaded', function () {
             initializeMap();
@@ -1921,6 +1935,26 @@
             setTimeout(() => {
                 showNotification('📸 Otomatik EXIF konum çıkarma aktif! Fotoğraf yüklediğinizde GPS bilgisi otomatik olarak haritaya eklenir.', 'info');
             }, 2000);
+
+            document.getElementById('btn-manual-location')?.addEventListener('click', () => {
+                const { lat, lon } = window.manualLocation || {};
+                if (lat != null && lon != null) {
+                    setLocationFromLatLon(lat, lon, { zoom: 16 });
+                }
+            });
+
+            document.querySelector('input[type="file"]')?.addEventListener('change', (e) => {
+                const file = e.target.files?.[0];
+                if (!file || !window.EXIF) return;
+
+                EXIF.getData(file, function () {
+                    const lat = dmsToDec(EXIF.getTag(this, 'GPSLatitude'), EXIF.getTag(this, 'GPSLatitudeRef'));
+                    const lon = dmsToDec(EXIF.getTag(this, 'GPSLongitude'), EXIF.getTag(this, 'GPSLongitudeRef'));
+                    if (lat != null && lon != null) {
+                        setLocationFromLatLon(lat, lon, { zoom: 16 });
+                    }
+                });
+            }, { capture: true });
         });
 
         // Cleanup on page unload


### PR DESCRIPTION
## Summary
- add exif-js dependency for client-side EXIF parsing
- extract location marker/form update logic into `setLocationFromLatLon`
- reuse location flow for manual clicks and EXIF GPS from file input

## Testing
- `pytest` *(fails: simple_test.py raises SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_68a7103e4a3c8320970c6ded632ab11b