### PR TITLE
Invalidate map size on window resize

### DIFF
--- a/static/js/mobile-optimizations.js
+++ b/static/js/mobile-optimizations.js
@@ -557,7 +557,13 @@ class MobileOptimizations {
     handleResize() {
         // Recalculate layout on resize
         this.optimizeForMobile();
-        
+        if (window.predefinedRoutesMap) {
+            window.predefinedRoutesMap.invalidateSize();
+        }
+        if (window.map) {
+            window.map.invalidateSize();
+        }
+
         // Close filter panel on desktop
         if (!this.isMobile && this.filterPanelExpanded) {
             this.closeFilterPanel();


### PR DESCRIPTION
## Summary
- Ensure both predefined and main map instances recalc size on window resize

## Testing
- ❌ `make quick` *(ruff found widespread issues)*
- ⚠️ `eslint static/js/mobile-optimizations.js` *(missing eslint.config)*
- ⚠️ `python tests/smoke.py` *(connection refused; API server not running)*

------
https://chatgpt.com/codex/tasks/task_e_68aea702e7488320b6e90e8ef3017eb6