### PR TITLE
feat: preserve routes map on orientation change

### DIFF
--- a/static/js/touch-optimizations.js
+++ b/static/js/touch-optimizations.js
@@ -348,6 +348,9 @@ class TouchOptimizer {
         if (typeof map !== 'undefined' && map) {
             setTimeout(() => {
                 map.invalidateSize();
+                if (typeof window.predefinedRoutesMap !== 'undefined' && window.predefinedRoutesMap) {
+                    window.predefinedRoutesMap.invalidateSize();
+                }
             }, 100);
         }
 


### PR DESCRIPTION
## Summary
- keep predefined routes map rendering after orientation changes by invalidating its size

## Testing
- `python run_all_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68aea83ce2a48320a48032688a6b75b7