### PR TITLE
Harita kapsayıcı kontrolü ve fitBounds yenilemesi

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5393,6 +5393,11 @@ async function initializePredefinedMap() {
 }
 
 async function displayRouteOnMap(route) {
+    const mapContainer = document.getElementById('predefinedRoutesMap');
+    if (!mapContainer || mapContainer.offsetWidth === 0 || mapContainer.offsetHeight === 0) {
+        setTimeout(() => displayRouteOnMap(route), 200);
+        return;
+    }
     console.log('🗺️ === DISPLAYING ROUTE ON MAP ===');
     console.log('🗺️ Displaying route on predefined map:', route);
     console.log('🔍 Route geometry:', route.geometry);
@@ -5416,7 +5421,6 @@ async function displayRouteOnMap(route) {
     });
     
     // Ensure map container is visible and invalidate size for proper rendering
-    const mapContainer = document.getElementById('predefinedRoutesMap');
     if (mapContainer) {
         mapContainer.style.display = 'block';
         mapContainer.style.visibility = 'visible';
@@ -5588,7 +5592,9 @@ async function displayRouteOnMap(route) {
                     
                     // Fit map to combined bounds (route + POIs)
                     predefinedMap.fitBounds(bounds, { padding: [20, 20] });
-                    
+                    predefinedMap.invalidateSize();
+                    predefinedMap.fitBounds(bounds, { padding: [20, 20] });
+
                     console.log('✅ Route with POIs displayed on predefined map');
                     
                     // Create elevation chart for predefined route with geometry
@@ -5726,6 +5732,8 @@ async function displayRouteOnMap(route) {
                 // Fit map to POI bounds
                 if (bounds.isValid()) {
                     predefinedMap.fitBounds(bounds, { padding: [30, 30] });
+                    predefinedMap.invalidateSize();
+                    predefinedMap.fitBounds(bounds, { padding: [20, 20] });
                 }
                 
                 console.log('✅ Route POIs displayed on predefined map');


### PR DESCRIPTION
## Summary
- Map container size check added to `displayRouteOnMap` with retry when container hidden
- Refresh map focus by refitting bounds after `invalidateSize()` for routes and POIs

## Testing
- `pytest -q` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68aeadf0ea6c832095dc658e4b1a8c94