### PR TITLE
Expose predefined routes map globally

### DIFF
--- a/static/js/poi_recommendation_system.js
+++ b/static/js/poi_recommendation_system.js
@@ -5318,9 +5318,10 @@ function initializePredefinedRoutes() {
 }
 
 // Predefined routes map management
-let predefinedMap = null;
-let predefinedMapLayers = [];
-let predefinedMapInitialized = false;
+// Make predefined map accessible globally for other scripts
+window.predefinedMap = null;
+window.predefinedMapLayers = [];
+window.predefinedMapInitialized = false;
 
 // Map initialization state management
 let mapInitializationPromise = null;


### PR DESCRIPTION
## Summary
- Expose predefined routes map variables on the global `window` object so other scripts can access the map and its layers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb52581248320b03cec3335962f6a