### PR TITLE
Fix predefined map reference on orientation change

### DIFF
--- a/static/js/touch-optimizations.js
+++ b/static/js/touch-optimizations.js
@@ -348,8 +348,8 @@ class TouchOptimizer {
         if (typeof map !== 'undefined' && map) {
             setTimeout(() => {
                 map.invalidateSize();
-                if (typeof window.predefinedRoutesMap !== 'undefined' && window.predefinedRoutesMap) {
-                    window.predefinedRoutesMap.invalidateSize();
+                if (typeof window.predefinedMap !== 'undefined' && window.predefinedMap) {
+                    window.predefinedMap.invalidateSize();
                 }
             }, 100);
         }


### PR DESCRIPTION
## Summary
- update touch-optimizations to use `window.predefinedMap` in `handleOrientationChange`

## Testing
- `make quick` *(fails: Ruff check failed)*
- `eslint static/js/touch-optimizations.js` *(fails: command not found)*
- `python3 tests/smoke.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68aeb6494b688320aae5c4d28815cbab